### PR TITLE
Fix K1 compiler error for lower versions of RN that still have kotlin < 2.+

### DIFF
--- a/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
+++ b/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
@@ -250,17 +250,8 @@ class AppstackReactNativeModule(reactContext: ReactApplicationContext) :
             // Convert Map<String, Any> to WritableMap using Arguments factory
             val writableMap = Arguments.createMap()
             
-            params?.forEach { (key, value) ->
-                when (value) {
-                    is String -> writableMap.putString(key, value)
-                    is Int -> writableMap.putInt(key, value)
-                    is Double -> writableMap.putDouble(key, value)
-                    is Boolean -> writableMap.putBoolean(key, value)
-                    is Long -> writableMap.putDouble(key, value.toDouble())
-                    is Float -> writableMap.putDouble(key, value.toDouble())
-                    null -> writableMap.putNull(key)
-                    else -> writableMap.putString(key, value.toString())
-                }
+            params.forEach { (key, value) ->
+                writableMap.putString(key, value)
             }
             
             promise.resolve(writableMap)


### PR DESCRIPTION
Build was failing in older versions of RN because we had defined unreachable types and k1 compiler was throwing error on build.


Closes #7 