### PR TITLE
Update changelog, add integration tests, and fix Android package instance declaration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,17 @@ permissions:
   contents: read
 
 jobs:
+  # Stable releases must pass integration tests first; -rc tags skip them
+  # so untested versions can still be published under the 'rc' dist-tag.
+  integration-tests:
+    if: ${{ !contains(github.ref_name, '-rc') }}
+    uses: ./.github/workflows/integration-tests.yml
+
   # Build and publish on version tags
   publish:
     runs-on: ubuntu-latest
+    needs: [integration-tests]
+    if: ${{ always() && (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped') }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,44 @@
+name: Integration Tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'android/**'
+      - 'ios/**'
+      - 'src/**'
+      - 'react-native.config.js'
+      - '*.podspec'
+      - 'package.json'
+      - 'integration-tests/**'
+      - '.github/workflows/integration-tests.yml'
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  android:
+    name: Android (Expo SDK ${{ matrix.expo-sdk }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # Add new Expo SDK majors here as they are released
+        expo-sdk: ['54', '55', '56']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Run integration test
+        run: ./integration-tests/run.sh ${{ matrix.expo-sdk }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the React Native Appstack SDK will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Android (Expo/EAS):** Fixed `package com.appstack.reactnative.com.appstack.reactnative does not exist` build error on Expo SDK 56 / React Native 0.84+. The new React Native Gradle plugin expands the package class name in `PackageList.java` to its fully-qualified name itself, so the fully-qualified `packageInstance` in `react-native.config.js` resulted in a duplicated package prefix. The instance is now declared unqualified, which works on both old and new toolchains.
+
+### Added
+- Integration tests (`integration-tests/run.sh` + CI matrix) that scaffold a fresh Expo app per supported SDK major (54/55/56), install the packed SDK tarball, run `expo prebuild` and compile the Android project. Stable npm publishes are now gated on these tests passing (`-rc` tags still publish without them).
+
 ## [2.2.0] - 2026-06-05
 
 ### Changed

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -euo pipefail
+
+# Integration test: verify the SDK autolinks and compiles in a fresh Expo app.
+#
+# Scaffolds a throwaway Expo app for the given SDK version, installs the packed
+# SDK tarball, runs `expo prebuild` and builds the Android project. Catches
+# autolinking/toolchain regressions (e.g. PackageList.java generation changes)
+# before they hit consumers.
+#
+# Usage: ./integration-tests/run.sh <expo-sdk-version> [--quick]
+#   <expo-sdk-version>  Expo SDK major version, e.g. 54, 55, 56
+#   --quick             Stop after the PackageList.java assertion (no full
+#                       Android compile). Useful for fast local iteration.
+
+SDK_VERSION="${1:?Usage: $0 <expo-sdk-version> [--quick]}"
+QUICK_MODE=false
+[[ "${2:-}" == "--quick" ]] && QUICK_MODE=true
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WORK_DIR="${INTEGRATION_WORK_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/appstack-e2e.XXXXXX")}"
+APP_NAME="e2e-sdk${SDK_VERSION}"
+APP_DIR="${WORK_DIR}/${APP_NAME}"
+
+log()  { echo "▶ $*"; }
+fail() { echo "❌ $*" >&2; exit 1; }
+
+log "Expo SDK ${SDK_VERSION} integration test (workdir: ${WORK_DIR})"
+
+# 1. Pack the SDK (prepack hook builds lib/ via bob)
+cd "$ROOT_DIR"
+if [[ ! -d node_modules ]]; then
+  log "Installing SDK dependencies..."
+  npm ci
+fi
+log "Packing SDK tarball..."
+rm -f "${WORK_DIR}"/react-native-appstack-sdk-*.tgz
+npm pack --pack-destination "$WORK_DIR" > /dev/null
+TARBALL="$(ls "${WORK_DIR}"/react-native-appstack-sdk-*.tgz)"
+log "Packed: $(basename "$TARBALL")"
+
+# 2. Scaffold a fresh Expo app for the target SDK version
+cd "$WORK_DIR"
+if [[ -d "$APP_DIR" ]]; then
+  log "Reusing existing app at ${APP_DIR} (delete it for a clean run)"
+else
+  log "Scaffolding Expo app (template blank@sdk-${SDK_VERSION})..."
+  npx --yes create-expo-app@latest "$APP_NAME" --template "blank@sdk-${SDK_VERSION}" --no-install
+  cd "$APP_DIR"
+  npm install --no-audit --no-fund
+fi
+cd "$APP_DIR"
+
+# 3. Install the packed SDK and set an Android package for prebuild
+log "Installing SDK tarball into the app..."
+npm install --no-audit --no-fund "$TARBALL"
+node -e "
+  const fs = require('fs');
+  const j = JSON.parse(fs.readFileSync('app.json', 'utf8'));
+  j.expo.android = { ...(j.expo.android || {}), package: 'com.appstack.e2e' };
+  fs.writeFileSync('app.json', JSON.stringify(j, null, 2));
+"
+
+# 4. Prebuild the Android project
+log "Running expo prebuild (android)..."
+rm -rf android
+CI=1 npx expo prebuild --platform android --no-install
+
+# 5. Generate PackageList.java and assert our package is linked correctly
+cd android
+log "Generating autolinking PackageList..."
+./gradlew --no-daemon :app:generateAutolinkingPackageList
+
+PKG_LIST="app/build/generated/autolinking/src/main/java/com/facebook/react/PackageList.java"
+[[ -f "$PKG_LIST" ]] || fail "PackageList.java was not generated at ${PKG_LIST}"
+
+grep -q "AppstackReactNativePackage" "$PKG_LIST" \
+  || fail "AppstackReactNativePackage missing from PackageList.java — SDK was not autolinked"
+if grep -q "com\.appstack\.reactnative\.com\.appstack" "$PKG_LIST"; then
+  grep -n "AppstackReactNativePackage" "$PKG_LIST" >&2
+  fail "Duplicated package prefix in PackageList.java (packageInstance must stay unqualified in react-native.config.js)"
+fi
+log "PackageList.java looks correct:"
+grep -n "AppstackReactNativePackage" "$PKG_LIST" | sed 's/^/    /'
+
+if [[ "$QUICK_MODE" == true ]]; then
+  log "✅ Quick mode: skipping full Android build"
+  exit 0
+fi
+
+# 6. Full Android compile (debug — same Java compile path that release uses)
+log "Building Android app (assembleDebug)..."
+./gradlew --no-daemon :app:assembleDebug
+
+log "✅ Expo SDK ${SDK_VERSION} integration test passed"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "scripts": {
     "test": "jest",
+    "test:integration": "./integration-tests/run.sh",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "prepack": "bob build",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -4,7 +4,10 @@ module.exports = {
       android: {
         sourceDir: './android',
         packageImportPath: 'import com.appstack.reactnative.AppstackReactNativePackage;',
-        packageInstance: 'new com.appstack.reactnative.AppstackReactNativePackage()',
+        // Must stay unqualified: since RN 0.84 (Expo SDK 56) the gradle plugin
+        // expands the class name to the FQCN from packageImportPath itself, so a
+        // fully-qualified instance gets the package prefix duplicated.
+        packageInstance: 'new AppstackReactNativePackage()',
         // Disable CMake autolinking - native build is handled by build.gradle externalNativeBuild
         // This prevents autolinking from trying to include codegen before it's generated
         cmakeListsPath: null,


### PR DESCRIPTION


- Fixed build error on Expo SDK 56 / React Native 0.84+ by updating the package instance declaration in `react-native.config.js` to be unqualified.
- Added integration tests to verify SDK autolinking and compilation in fresh Expo apps, with a CI workflow to ensure stable npm publishes.
- Updated `CHANGELOG.md` to reflect these changes and improvements.