### PR TITLE
Enhance integration tests for iOS and Android, update changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Keep SHA-pinned GitHub Actions up to date
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,10 @@ jobs:
     needs: [integration-tests]
     if: ${{ always() && (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped') }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        persist-credentials: false
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '18'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,6 +15,15 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
+# A new push to the same PR cancels its superseded in-progress run.
+# Tag/release runs have unique refs and are never affected.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   android:
     name: Android (Expo SDK ${{ matrix.expo-sdk }})
@@ -23,22 +32,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Add new Expo SDK majors here as they are released
+        # Keep in sync with the ios job's expo-sdk list below
         expo-sdk: ['54', '55', '56']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
           cache: 'npm'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: 'temurin'
           java-version: '17'
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
 
       - name: Run integration test
         run: ./integration-tests/run.sh ${{ matrix.expo-sdk }}
@@ -50,18 +61,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Add new Expo SDK majors here as they are released
+        # Keep in sync with the android job's expo-sdk list above
         expo-sdk: ['54', '55', '56']
         frameworks: ['default']
         include:
           # Static frameworks exercise different header search paths
-          # (common setup in apps using Firebase and similar pods)
+          # (common setup in apps using Firebase and similar pods).
+          # Runs only against the latest SDK to keep the matrix lean.
           - expo-sdk: '56'
             frameworks: 'static'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,3 +42,31 @@ jobs:
 
       - name: Run integration test
         run: ./integration-tests/run.sh ${{ matrix.expo-sdk }}
+
+  ios:
+    name: iOS (Expo SDK ${{ matrix.expo-sdk }}, ${{ matrix.frameworks }} frameworks)
+    runs-on: macos-26
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        # Add new Expo SDK majors here as they are released
+        expo-sdk: ['54', '55', '56']
+        frameworks: ['default']
+        include:
+          # Static frameworks exercise different header search paths
+          # (common setup in apps using Firebase and similar pods)
+          - expo-sdk: '56'
+            frameworks: 'static'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Run integration test
+        run: >
+          ./integration-tests/run.sh ${{ matrix.expo-sdk }} --platform ios
+          ${{ matrix.frameworks == 'static' && '--static-frameworks' || '' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Android (Expo/EAS):** Fixed `package com.appstack.reactnative.com.appstack.reactnative does not exist` build error on Expo SDK 56 / React Native 0.84+. The new React Native Gradle plugin expands the package class name in `PackageList.java` to its fully-qualified name itself, so the fully-qualified `packageInstance` in `react-native.config.js` resulted in a duplicated package prefix. The instance is now declared unqualified, which works on both old and new toolchains.
 
 ### Added
-- Integration tests (`integration-tests/run.sh` + CI matrix) that scaffold a fresh Expo app per supported SDK major (54/55/56), install the packed SDK tarball, run `expo prebuild` and compile the Android project. Stable npm publishes are now gated on these tests passing (`-rc` tags still publish without them).
+- Integration tests (`integration-tests/run.sh` + CI matrix) that scaffold a fresh Expo app per supported SDK major (54/55/56), install the packed SDK tarball, run `expo prebuild` and build the native projects: Android (autolinking `PackageList.java` assertion + Gradle build) and iOS (`Podfile.lock` autolinking assertion + simulator `xcodebuild`, including a static-frameworks variant). Stable npm publishes are now gated on these tests passing (`-rc` tags still publish without them).
 
 ## [2.2.0] - 2026-06-05
 

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -4,18 +4,34 @@ set -euo pipefail
 # Integration test: verify the SDK autolinks and compiles in a fresh Expo app.
 #
 # Scaffolds a throwaway Expo app for the given SDK version, installs the packed
-# SDK tarball, runs `expo prebuild` and builds the Android project. Catches
-# autolinking/toolchain regressions (e.g. PackageList.java generation changes)
-# before they hit consumers.
+# SDK tarball, runs `expo prebuild` and builds the native project. Catches
+# autolinking/toolchain regressions (e.g. PackageList.java generation changes,
+# podspec header path issues) before they hit consumers.
 #
-# Usage: ./integration-tests/run.sh <expo-sdk-version> [--quick]
-#   <expo-sdk-version>  Expo SDK major version, e.g. 54, 55, 56
-#   --quick             Stop after the PackageList.java assertion (no full
-#                       Android compile). Useful for fast local iteration.
+# Usage: ./integration-tests/run.sh <expo-sdk-version> [options]
+#   <expo-sdk-version>    Expo SDK major version, e.g. 54, 55, 56
+#   --platform <p>        android (default) or ios
+#   --quick               Stop after the autolinking assertion (no full native
+#                         build). Useful for fast local iteration.
+#   --static-frameworks   iOS only: build with `useFrameworks: "static"` via
+#                         expo-build-properties (exercises different header
+#                         search paths, common in apps using Firebase etc.)
 
-SDK_VERSION="${1:?Usage: $0 <expo-sdk-version> [--quick]}"
+SDK_VERSION="${1:?Usage: $0 <expo-sdk-version> [--platform android|ios] [--quick] [--static-frameworks]}"
+shift
+
+PLATFORM="android"
 QUICK_MODE=false
-[[ "${2:-}" == "--quick" ]] && QUICK_MODE=true
+STATIC_FRAMEWORKS=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --platform) PLATFORM="${2:?--platform requires a value}"; shift 2 ;;
+    --quick) QUICK_MODE=true; shift ;;
+    --static-frameworks) STATIC_FRAMEWORKS=true; shift ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+[[ "$PLATFORM" == "android" || "$PLATFORM" == "ios" ]] || { echo "Invalid platform: $PLATFORM" >&2; exit 2; }
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 WORK_DIR="${INTEGRATION_WORK_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/appstack-e2e.XXXXXX")}"
@@ -25,7 +41,7 @@ APP_DIR="${WORK_DIR}/${APP_NAME}"
 log()  { echo "▶ $*"; }
 fail() { echo "❌ $*" >&2; exit 1; }
 
-log "Expo SDK ${SDK_VERSION} integration test (workdir: ${WORK_DIR})"
+log "Expo SDK ${SDK_VERSION} / ${PLATFORM} integration test (workdir: ${WORK_DIR})"
 
 # 1. Pack the SDK (prepack hook builds lib/ via bob)
 cd "$ROOT_DIR"
@@ -51,45 +67,91 @@ else
 fi
 cd "$APP_DIR"
 
-# 3. Install the packed SDK and set an Android package for prebuild
+# 3. Install the packed SDK and configure app.json for non-interactive prebuild
 log "Installing SDK tarball into the app..."
 npm install --no-audit --no-fund "$TARBALL"
-node -e "
+if [[ "$STATIC_FRAMEWORKS" == true ]]; then
+  npm install --no-audit --no-fund expo-build-properties
+fi
+STATIC_FRAMEWORKS="$STATIC_FRAMEWORKS" node -e "
   const fs = require('fs');
   const j = JSON.parse(fs.readFileSync('app.json', 'utf8'));
   j.expo.android = { ...(j.expo.android || {}), package: 'com.appstack.e2e' };
+  j.expo.ios = { ...(j.expo.ios || {}), bundleIdentifier: 'com.appstack.e2e' };
+  // Normalize the expo-build-properties plugin so reused app dirs don't leak
+  // a previous run's framework setting.
+  const plugins = (j.expo.plugins || []).filter(
+    (p) => (Array.isArray(p) ? p[0] : p) !== 'expo-build-properties'
+  );
+  if (process.env.STATIC_FRAMEWORKS === 'true') {
+    plugins.push(['expo-build-properties', { ios: { useFrameworks: 'static' } }]);
+  }
+  j.expo.plugins = plugins;
   fs.writeFileSync('app.json', JSON.stringify(j, null, 2));
 "
 
-# 4. Prebuild the Android project
-log "Running expo prebuild (android)..."
-rm -rf android
-CI=1 npx expo prebuild --platform android --no-install
+# 4. Prebuild the native project
+log "Running expo prebuild (${PLATFORM})..."
+rm -rf "$PLATFORM"
+CI=1 npx expo prebuild --platform "$PLATFORM" --no-install
 
-# 5. Generate PackageList.java and assert our package is linked correctly
-cd android
-log "Generating autolinking PackageList..."
-./gradlew --no-daemon :app:generateAutolinkingPackageList
+if [[ "$PLATFORM" == "android" ]]; then
+  # 5a. Generate PackageList.java and assert our package is linked correctly
+  cd android
+  log "Generating autolinking PackageList..."
+  ./gradlew --no-daemon :app:generateAutolinkingPackageList
 
-PKG_LIST="app/build/generated/autolinking/src/main/java/com/facebook/react/PackageList.java"
-[[ -f "$PKG_LIST" ]] || fail "PackageList.java was not generated at ${PKG_LIST}"
+  PKG_LIST="app/build/generated/autolinking/src/main/java/com/facebook/react/PackageList.java"
+  [[ -f "$PKG_LIST" ]] || fail "PackageList.java was not generated at ${PKG_LIST}"
 
-grep -q "AppstackReactNativePackage" "$PKG_LIST" \
-  || fail "AppstackReactNativePackage missing from PackageList.java — SDK was not autolinked"
-if grep -q "com\.appstack\.reactnative\.com\.appstack" "$PKG_LIST"; then
-  grep -n "AppstackReactNativePackage" "$PKG_LIST" >&2
-  fail "Duplicated package prefix in PackageList.java (packageInstance must stay unqualified in react-native.config.js)"
+  grep -q "AppstackReactNativePackage" "$PKG_LIST" \
+    || fail "AppstackReactNativePackage missing from PackageList.java — SDK was not autolinked"
+  if grep -q "com\.appstack\.reactnative\.com\.appstack" "$PKG_LIST"; then
+    grep -n "AppstackReactNativePackage" "$PKG_LIST" >&2
+    fail "Duplicated package prefix in PackageList.java (packageInstance must stay unqualified in react-native.config.js)"
+  fi
+  log "PackageList.java looks correct:"
+  grep -n "AppstackReactNativePackage" "$PKG_LIST" | sed 's/^/    /'
+
+  if [[ "$QUICK_MODE" == true ]]; then
+    log "✅ Quick mode: skipping full Android build"
+    exit 0
+  fi
+
+  # 6a. Full Android compile (debug — same Java compile path that release uses)
+  log "Building Android app (assembleDebug)..."
+  ./gradlew --no-daemon :app:assembleDebug
+else
+  # 5b. Install pods and assert the SDK pod was autolinked
+  cd ios
+  log "Installing pods..."
+  # CocoaPods crashes on non-UTF-8 locales (common in minimal CI shells)
+  export LANG="${LANG:-en_US.UTF-8}" LC_ALL="${LC_ALL:-en_US.UTF-8}"
+  pod install
+
+  grep -q "react-native-appstack-sdk" Podfile.lock \
+    || fail "react-native-appstack-sdk missing from Podfile.lock — SDK was not autolinked"
+  log "Podfile.lock looks correct:"
+  grep -n "react-native-appstack-sdk" Podfile.lock | head -5 | sed 's/^/    /'
+
+  if [[ "$QUICK_MODE" == true ]]; then
+    log "✅ Quick mode: skipping full iOS build"
+    exit 0
+  fi
+
+  # 6b. Full simulator build (no signing required)
+  WORKSPACE="$(ls -d *.xcworkspace | head -1)"
+  SCHEME="${WORKSPACE%.xcworkspace}"
+  log "Building iOS app (xcodebuild, scheme ${SCHEME})..."
+  xcodebuild -workspace "$WORKSPACE" \
+    -scheme "$SCHEME" \
+    -configuration Debug \
+    -sdk iphonesimulator \
+    -destination 'generic/platform=iOS Simulator' \
+    -derivedDataPath build \
+    CODE_SIGNING_ALLOWED=NO \
+    COMPILER_INDEX_STORE_ENABLE=NO \
+    build
 fi
-log "PackageList.java looks correct:"
-grep -n "AppstackReactNativePackage" "$PKG_LIST" | sed 's/^/    /'
 
-if [[ "$QUICK_MODE" == true ]]; then
-  log "✅ Quick mode: skipping full Android build"
-  exit 0
-fi
-
-# 6. Full Android compile (debug — same Java compile path that release uses)
-log "Building Android app (assembleDebug)..."
-./gradlew --no-daemon :app:assembleDebug
-
-log "✅ Expo SDK ${SDK_VERSION} integration test passed"
+log "✅ Expo SDK ${SDK_VERSION} / ${PLATFORM} integration test passed"


### PR DESCRIPTION
- Expanded integration tests to include iOS builds and static frameworks support, ensuring comprehensive coverage for Expo SDK versions 54, 55, and 56.
- Updated `integration-tests/run.sh` to support platform selection and static frameworks, improving test flexibility.
- Revised `CHANGELOG.md` to document these enhancements and changes.