### PR TITLE
Clean up bridging logs and tests dev configuration

### DIFF
--- a/__tests__/AppstackSDK.test.ts
+++ b/__tests__/AppstackSDK.test.ts
@@ -66,7 +66,8 @@ describe('AppstackSDK', () => {
       const result = await appstackSDK.configure('my-api-key');
       expect(result).toBe(true);
       expect(mockNative.configure).toHaveBeenCalledTimes(1);
-      expect(mockNative.configure).toHaveBeenCalledWith('my-api-key', false, null, 1, null);
+      // isDebug is validated on the JS side but not forwarded to native.
+      expect(mockNative.configure).toHaveBeenCalledWith('my-api-key', null, 1, null);
     });
 
     it('calls native configure with all options including customerUserId', async () => {
@@ -80,7 +81,6 @@ describe('AppstackSDK', () => {
       expect(result).toBe(true);
       expect(mockNative.configure).toHaveBeenCalledWith(
         'my-api-key',
-        true,
         'https://custom.endpoint/',
         0,
         'user-123'
@@ -89,22 +89,22 @@ describe('AppstackSDK', () => {
 
     it('passes null for optional customerUserId when not provided', async () => {
       await appstackSDK.configure('key', false, undefined, 1);
-      expect(mockNative.configure).toHaveBeenCalledWith('key', false, null, 1, null);
+      expect(mockNative.configure).toHaveBeenCalledWith('key', null, 1, null);
     });
 
     it('passes null when customerUserId is explicitly null', async () => {
       await appstackSDK.configure('key', false, undefined, 1, null);
-      expect(mockNative.configure).toHaveBeenCalledWith('key', false, null, 1, null);
+      expect(mockNative.configure).toHaveBeenCalledWith('key', null, 1, null);
     });
 
     it('trims apiKey and endpointBaseUrl', async () => {
       await appstackSDK.configure('  key  ', false, '  https://x.com  ', 1);
-      expect(mockNative.configure).toHaveBeenCalledWith('key', false, 'https://x.com', 1, null);
+      expect(mockNative.configure).toHaveBeenCalledWith('key', 'https://x.com', 1, null);
     });
 
     it('trims customerUserId when provided', async () => {
       await appstackSDK.configure('key', false, undefined, 1, '  user-456  ');
-      expect(mockNative.configure).toHaveBeenCalledWith('key', false, null, 1, 'user-456');
+      expect(mockNative.configure).toHaveBeenCalledWith('key', null, 1, 'user-456');
     });
 
     it('throws when apiKey is empty', async () => {

--- a/__tests__/AppstackSDK.test.ts
+++ b/__tests__/AppstackSDK.test.ts
@@ -66,8 +66,8 @@ describe('AppstackSDK', () => {
       const result = await appstackSDK.configure('my-api-key');
       expect(result).toBe(true);
       expect(mockNative.configure).toHaveBeenCalledTimes(1);
-      // isDebug is validated on the JS side but not forwarded to native.
-      expect(mockNative.configure).toHaveBeenCalledWith('my-api-key', null, 1, null);
+      // isDebug and endpointBaseUrl are validated on the JS side but not forwarded to native.
+      expect(mockNative.configure).toHaveBeenCalledWith('my-api-key', 1, null);
     });
 
     it('calls native configure with all options including customerUserId', async () => {
@@ -79,32 +79,27 @@ describe('AppstackSDK', () => {
         'user-123'
       );
       expect(result).toBe(true);
-      expect(mockNative.configure).toHaveBeenCalledWith(
-        'my-api-key',
-        'https://custom.endpoint/',
-        0,
-        'user-123'
-      );
+      expect(mockNative.configure).toHaveBeenCalledWith('my-api-key', 0, 'user-123');
     });
 
     it('passes null for optional customerUserId when not provided', async () => {
       await appstackSDK.configure('key', false, undefined, 1);
-      expect(mockNative.configure).toHaveBeenCalledWith('key', null, 1, null);
+      expect(mockNative.configure).toHaveBeenCalledWith('key', 1, null);
     });
 
     it('passes null when customerUserId is explicitly null', async () => {
       await appstackSDK.configure('key', false, undefined, 1, null);
-      expect(mockNative.configure).toHaveBeenCalledWith('key', null, 1, null);
+      expect(mockNative.configure).toHaveBeenCalledWith('key', 1, null);
     });
 
-    it('trims apiKey and endpointBaseUrl', async () => {
+    it('trims apiKey (endpointBaseUrl is accepted but not forwarded)', async () => {
       await appstackSDK.configure('  key  ', false, '  https://x.com  ', 1);
-      expect(mockNative.configure).toHaveBeenCalledWith('key', 'https://x.com', 1, null);
+      expect(mockNative.configure).toHaveBeenCalledWith('key', 1, null);
     });
 
     it('trims customerUserId when provided', async () => {
       await appstackSDK.configure('key', false, undefined, 1, '  user-456  ');
-      expect(mockNative.configure).toHaveBeenCalledWith('key', null, 1, 'user-456');
+      expect(mockNative.configure).toHaveBeenCalledWith('key', 1, 'user-456');
     });
 
     it('throws when apiKey is empty', async () => {

--- a/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
+++ b/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
@@ -23,7 +23,7 @@ class AppstackReactNativeModule(reactContext: ReactApplicationContext) :
     // setProxyUrl + configureWrapper are gated behind @RequiresOptIn(InternalAppstackApi).
     @OptIn(com.appstack.attribution.InternalAppstackApi::class)
     @ReactMethod
-    fun configure(apiKey: String, endpointBaseUrl: String?, logLevel: Int, customerUserId: String?, promise: Promise) {
+    fun configure(apiKey: String, logLevel: Int, customerUserId: String?, promise: Promise) {
         try {
             if (apiKey.isBlank()) {
                 promise.reject("INVALID_API_KEY", "API key cannot be null or empty")

--- a/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
+++ b/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
@@ -1,6 +1,7 @@
 package com.appstack.reactnative
 
 import android.content.Context
+import android.content.pm.PackageManager
 import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
 // Import the SDK from the Maven dependency
@@ -53,6 +54,16 @@ class AppstackReactNativeModule(reactContext: ReactApplicationContext) :
                 return
             }
 
+            // Testing-only proxy override, read from the app's manifest metadata. This is
+            // NOT exposed through the public configure() API: a proxy URL is applied only if
+            // the host app deliberately ships an APPSTACK_DEV_PROXY_URL <meta-data> entry
+            // (this repo's homepage-app does; published-package consumers do not). Routed
+            // through the SDK's internal setProxyUrl hook, before configure so the SDK's
+            // initial requests target it.
+            readDevProxyUrl()?.takeIf { it.isNotBlank() }?.let {
+                AppstackAttributionSdk.setProxyUrl(it)
+            }
+
             // configureWrapper is the internal entry point that still accepts the RN wrapper version.
             AppstackAttributionSdk.configureWrapper(
                 context = context,
@@ -65,6 +76,23 @@ class AppstackReactNativeModule(reactContext: ReactApplicationContext) :
             promise.resolve(true)
         } catch (exception: Exception) {
             promise.reject("CONFIGURATION_ERROR", "Failed to configure SDK: ${exception.message}", exception)
+        }
+    }
+
+    /**
+     * Reads the repo-only APPSTACK_DEV_PROXY_URL <meta-data> value from the host app's
+     * manifest, mirroring the iOS Info.plist key of the same name. Returns null when the
+     * key is absent (the published-package case).
+     */
+    private fun readDevProxyUrl(): String? {
+        return try {
+            val appInfo = reactApplicationContext.packageManager.getApplicationInfo(
+                reactApplicationContext.packageName,
+                PackageManager.GET_META_DATA
+            )
+            appInfo.metaData?.getString("APPSTACK_DEV_PROXY_URL")
+        } catch (e: Exception) {
+            null
         }
     }
 

--- a/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
+++ b/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
@@ -8,40 +8,16 @@ import com.appstack.attribution.AppstackAttributionSdk
 import com.appstack.attribution.EventType
 
 @ReactModule(name = AppstackReactNativeModule.NAME)
-class AppstackReactNativeModule(reactContext: ReactApplicationContext) : 
-    ReactContextBaseJavaModule(reactContext),
-    LifecycleEventListener {
+class AppstackReactNativeModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
 
     companion object {
         const val NAME = "AppstackReactNative"
         private const val WRAPPER_VERSION = "react-native-1.0.0"
     }
 
-    init {
-        // Register lifecycle listener to handle app background/foreground events
-        reactContext.addLifecycleEventListener(this)
-    }
-
     override fun getName(): String {
         return NAME
-    }
-
-    override fun onHostResume() {
-        // App came to foreground
-    }
-
-    override fun onHostPause() {
-        // App went to background
-    }
-
-    override fun onHostDestroy() {
-        // App destroyed
-    }
-
-    override fun onCatalystInstanceDestroy() {
-        super.onCatalystInstanceDestroy()
-        // Clean up lifecycle listener
-        reactApplicationContext.removeLifecycleEventListener(this)
     }
 
     // setProxyUrl + configureWrapper are gated behind @RequiresOptIn(InternalAppstackApi).
@@ -163,12 +139,6 @@ class AppstackReactNativeModule(reactContext: ReactApplicationContext) :
     fun enableAppleAdsAttribution(promise: Promise) {
         // Apple Ads Attribution is iOS-only, so we return false on Android
         promise.resolve(false)
-    }
-
-    @ReactMethod
-    fun flush(promise: Promise) {
-        // Events are sent immediately; flush is a no-op.
-        promise.resolve(true)
     }
 
     @ReactMethod

--- a/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
+++ b/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
@@ -1,7 +1,6 @@
 package com.appstack.reactnative
 
 import android.content.Context
-import android.util.Log
 import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
 // Import the SDK from the Maven dependency
@@ -15,7 +14,6 @@ class AppstackReactNativeModule(reactContext: ReactApplicationContext) :
 
     companion object {
         const val NAME = "AppstackReactNative"
-        private const val TAG = "AppstackReactNativeModule"
         private const val WRAPPER_VERSION = "react-native-1.0.0"
     }
 
@@ -30,15 +28,14 @@ class AppstackReactNativeModule(reactContext: ReactApplicationContext) :
 
     override fun onHostResume() {
         // App came to foreground
-        Log.d(TAG, "App resumed (foreground)")
     }
 
     override fun onHostPause() {
-        Log.d(TAG, "App paused (background)")
+        // App went to background
     }
 
     override fun onHostDestroy() {
-        Log.d(TAG, "App destroyed")
+        // App destroyed
     }
 
     override fun onCatalystInstanceDestroy() {
@@ -52,8 +49,6 @@ class AppstackReactNativeModule(reactContext: ReactApplicationContext) :
     @ReactMethod
     fun configure(apiKey: String, isDebug: Boolean, endpointBaseUrl: String?, logLevel: Int, customerUserId: String?, promise: Promise) {
         try {
-            Log.d(TAG, "Configuring Appstack SDK with API key: ${apiKey.take(8)}...")
-            
             if (apiKey.isBlank()) {
                 promise.reject("INVALID_API_KEY", "API key cannot be null or empty")
                 return
@@ -76,24 +71,11 @@ class AppstackReactNativeModule(reactContext: ReactApplicationContext) :
 
             // Validate that SDK classes are available
             try {
-                Log.d(TAG, "Checking SDK class availability...")
-                val sdkClass = AppstackAttributionSdk::class.java
-                Log.d(TAG, "All SDK classes are available")
+                AppstackAttributionSdk::class.java
             } catch (e: Exception) {
-                Log.e(TAG, "SDK classes not available", e)
                 promise.reject("SDK_CLASSES_ERROR", "SDK classes not available: ${e.message}", e)
                 return
             }
-            
-            // Check if SDK is already initialized
-            try {
-                val isAlreadyEnabled = AppstackAttributionSdk.isEnabled()
-                Log.d(TAG, "SDK current status before init: isEnabled=$isAlreadyEnabled")
-            } catch (e: Exception) {
-                Log.d(TAG, "Could not check SDK status before init: ${e.message}")
-            }
-            
-            Log.d(TAG, "Calling AppstackAttributionSdk.configureWrapper...")
 
             // configureWrapper is the internal entry point that still accepts the RN wrapper version.
             AppstackAttributionSdk.configureWrapper(
@@ -104,10 +86,8 @@ class AppstackReactNativeModule(reactContext: ReactApplicationContext) :
                 customerUserId = customerUserId?.takeIf { it.isNotBlank() }
             )
 
-            Log.d(TAG, "SDK configure method called successfully")
             promise.resolve(true)
         } catch (exception: Exception) {
-            Log.e(TAG, "Exception during SDK configuration", exception)
             promise.reject("CONFIGURATION_ERROR", "Failed to configure SDK: ${exception.message}", exception)
         }
     }

--- a/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
+++ b/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
@@ -23,7 +23,7 @@ class AppstackReactNativeModule(reactContext: ReactApplicationContext) :
     // setProxyUrl + configureWrapper are gated behind @RequiresOptIn(InternalAppstackApi).
     @OptIn(com.appstack.attribution.InternalAppstackApi::class)
     @ReactMethod
-    fun configure(apiKey: String, isDebug: Boolean, endpointBaseUrl: String?, logLevel: Int, customerUserId: String?, promise: Promise) {
+    fun configure(apiKey: String, endpointBaseUrl: String?, logLevel: Int, customerUserId: String?, promise: Promise) {
         try {
             if (apiKey.isBlank()) {
                 promise.reject("INVALID_API_KEY", "API key cannot be null or empty")

--- a/homepage-app/app.json
+++ b/homepage-app/app.json
@@ -9,7 +9,7 @@
     "userInterfaceStyle": "automatic",
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.example.homepageapp",
+      "bundleIdentifier": "com.example.homepageapp"
     },
     "android": {
       "adaptiveIcon": {

--- a/homepage-app/app.json
+++ b/homepage-app/app.json
@@ -9,7 +9,7 @@
     "userInterfaceStyle": "automatic",
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.tomrlas.homepageapp"
+      "bundleIdentifier": "com.example.homepageapp",
     },
     "android": {
       "adaptiveIcon": {
@@ -17,7 +17,7 @@
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true,
-      "package": "com.tomrlas.homepageapp"
+      "package": "com.example.homepageapp"
     },
     "web": {
       "bundler": "metro",
@@ -36,6 +36,7 @@
         }
       ],
       "../plugin/build",
+      "./plugins/withAppstackDevProxy",
       "expo-web-browser",
       "expo-font"
     ],

--- a/homepage-app/plugins/withAppstackDevProxy.js
+++ b/homepage-app/plugins/withAppstackDevProxy.js
@@ -1,0 +1,37 @@
+const {
+  withInfoPlist,
+  withAndroidManifest,
+  AndroidConfig,
+} = require('@expo/config-plugins');
+
+// Repo-only Expo config plugin. Injects the Appstack dev proxy URL as a native
+// manifest key on both platforms so THIS test app targets the dev environment via
+// the SDK bridge's internal setProxyUrl hook (see AppstackBridge.swift /
+// AppstackReactNativeModule.kt, which read APPSTACK_DEV_PROXY_URL).
+//
+// It is NOT part of the published react-native-appstack-sdk package: only the
+// homepage-app's app.json references this plugin, so integrators' apps never ship
+// the key and always hit production. This mirrors the Flutter sample_app's
+// Info.plist / AndroidManifest APPSTACK_DEV_PROXY_URL hook.
+const KEY = 'APPSTACK_DEV_PROXY_URL';
+const IOS_DEV_PROXY = 'https://api.event.dev.appstack.tech';
+const ANDROID_DEV_PROXY = 'https://api.event.dev.appstack.tech/android/';
+
+module.exports = function withAppstackDevProxy(config) {
+  config = withInfoPlist(config, (cfg) => {
+    cfg.modResults[KEY] = IOS_DEV_PROXY;
+    return cfg;
+  });
+
+  config = withAndroidManifest(config, (cfg) => {
+    const app = AndroidConfig.Manifest.getMainApplicationOrThrow(cfg.modResults);
+    AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+      app,
+      KEY,
+      ANDROID_DEV_PROXY
+    );
+    return cfg;
+  });
+
+  return config;
+};

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -54,10 +54,12 @@ APP_DIR="${WORK_DIR}/${APP_NAME}"
 log()  { echo "▶ $*"; }
 fail() { echo "❌ $*" >&2; exit 1; }
 
-# Distinctive values the smoke entrypoint passes to configure(). The run_*_smoke
-# assertions grep the native bridge logs for these to confirm the arguments
-# actually marshal across the JS <-> native boundary (Tier 1 value check), not
-# just that the method was called. Keep them recognizable and stable.
+# Values the smoke entrypoint passes to configure(). The bridge no longer logs
+# its arguments (device logging is delegated to the native SDK's sanitized,
+# level-gated logger), so these are not asserted against logs; the configure ->
+# sendEvent -> getAppstackId round trip — and the UUID getAppstackId returns — is
+# what proves the arguments marshaled across the boundary. Kept distinctive so
+# they stand out in captured log dumps when a run fails.
 SMOKE_API_KEY="SMOKEKEY-abc12345"
 SMOKE_LOG_LEVEL="2"
 SMOKE_USER_ID="smoke-user-42"
@@ -84,17 +86,17 @@ import React, { useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import AppstackSDK, { EventType } from 'react-native-appstack-sdk';
 JS_HEAD
-    printf '\n// Distinctive values injected by run.sh --smoke; the shell asserts the native\n'
-    printf '// bridge logs echo these back (Tier 1 argument-marshaling check).\n'
+    printf '\n// Values injected by run.sh --smoke and passed straight into configure().\n'
+    printf '// Not asserted against logs anymore; the round trip below is the check.\n'
     printf "const SMOKE_API_KEY = '%s';\n" "$SMOKE_API_KEY"
     printf 'const SMOKE_LOG_LEVEL = %s;\n' "$SMOKE_LOG_LEVEL"
     printf "const SMOKE_USER_ID = '%s';\n" "$SMOKE_USER_ID"
     cat <<'JS_BODY'
 
 // Smoke entrypoint injected by integration-tests/run.sh --smoke.
-// Exercises the JS -> bridge -> native round trip with known argument values and
-// logs a sentinel CI greps for. A fake API key is fine: we assert the bridge
-// received our values and resolved, not that the backend accepts them.
+// Exercises the JS -> bridge -> native round trip and logs a sentinel CI greps
+// for. A fake API key is fine: we assert the round trip resolves and
+// getAppstackId returns a real UUID, not that the backend accepts the key.
 export default function App() {
   const [status, setStatus] = useState('APPSTACK_SMOKE_RUNNING');
   useEffect(() => {
@@ -154,7 +156,6 @@ run_android_smoke() {
     || fail "Failed to launch $pkg"
 
   local ok_js="APPSTACK_SMOKE_OK"
-  local ok_native="SDK configure method called successfully"  # supplemental only
   local fail_js="APPSTACK_SMOKE_FAIL"
 
   log "Waiting for SDK round-trip sentinel in logcat (up to 90s)..."
@@ -178,18 +179,6 @@ run_android_smoke() {
     if grep -qF "$ok_js" <<<"$dump"; then
       log "Smoke sentinel found (JS round-trip complete):"
       grep -F "$ok_js" <<<"$dump" | head -1 | sed 's/^/    /'
-      if grep -qF "$ok_native" <<<"$dump"; then
-        grep -F "$ok_native" <<<"$dump" | head -1 | sed 's/^/    (native) /'
-      fi
-      # Tier 1 value check: the Android bridge logs only the apiKey prefix
-      # (apiKey.take(8)), so assert that marshaled across the boundary.
-      local key_prefix="${SMOKE_API_KEY:0:8}"
-      if grep -qF "API key: ${key_prefix}" <<<"$dump"; then
-        log "Arg check OK: native bridge received apiKey prefix '${key_prefix}'"
-      else
-        grep -F "Configuring Appstack SDK" <<<"$dump" | head -3 >&2 || true
-        fail "Value check FAILED: apiKey did not reach native as '${key_prefix}...'"
-      fi
       return 0
     fi
     sleep 2
@@ -200,11 +189,11 @@ run_android_smoke() {
 }
 
 # Install the .app on a booted simulator, launch it, and poll the unified log for
-# the sentinel. Success REQUIRES the JS sentinel APPSTACK_SMOKE_OK (emitted only
-# after the full configure -> sendEvent -> getAppstackId round trip); the RCT
-# bridge's native "configure method called successfully via bridge" NSLog is
-# supplemental output only, since it fires on configure alone and would otherwise
-# let the check pass early.
+# the sentinel. Success REQUIRES the JS sentinel APPSTACK_SMOKE_OK, emitted only
+# after the full configure -> sendEvent -> getAppstackId round trip. The bridge
+# itself no longer logs (device logging is delegated to the native SDK's
+# sanitized, level-gated logger), so the JS sentinel is the sole signal — and the
+# getAppstackId UUID it carries is native-backed proof the SDK initialized.
 run_ios_smoke() {
   local app_path="$1" bundle_id="$2"
   [[ -d "$app_path" ]] || fail ".app not found at $app_path"
@@ -223,11 +212,11 @@ run_ios_smoke() {
   log "Installing app on simulator: $(basename "$app_path")"
   xcrun simctl install "$udid" "$app_path" || fail "simctl install failed"
 
-  # Capture the unified log (NSLog + any os_log-routed JS output) in the
-  # background, filtered to our bridge/sentinel to keep it cheap.
+  # Capture the unified log (JS console output routed to os_log) in the
+  # background, filtered to our sentinel to keep it cheap.
   local capture; capture="$(mktemp "${TMPDIR:-/tmp}/appstack-ios-smoke.XXXXXX")"
   xcrun simctl spawn "$udid" log stream --level debug --style syslog \
-    --predicate 'eventMessage CONTAINS "AppstackReactNative" OR eventMessage CONTAINS "APPSTACK_SMOKE"' \
+    --predicate 'eventMessage CONTAINS "APPSTACK_SMOKE"' \
     > "$capture" 2>/dev/null &
   local log_pid=$!
   sleep 1
@@ -237,7 +226,6 @@ run_ios_smoke() {
     || { kill "$log_pid" 2>/dev/null || true; fail "simctl launch failed"; }
 
   local ok_js="APPSTACK_SMOKE_OK"
-  local ok_native="configure method called successfully via bridge"  # supplemental only
   local fail_js="APPSTACK_SMOKE_FAIL"
 
   log "Waiting for SDK round-trip sentinel in the simulator log (up to 90s)..."
@@ -262,22 +250,6 @@ run_ios_smoke() {
   if [[ "$found" == true ]]; then
     log "Smoke sentinel found (JS round-trip complete):"
     grep -F "$ok_js" "$capture" | head -1 | sed 's/^/    /'
-    if grep -qF "$ok_native" "$capture"; then
-      grep -F "$ok_native" "$capture" | head -1 | sed 's/^/    (native) /'
-    fi
-    # Tier 1 value check: the iOS bridge logs every configure arg, so assert the
-    # apiKey, logLevel, and customerUserId all marshaled across the boundary.
-    local args_ok=true
-    grep -qF "apiKey: ${SMOKE_API_KEY}" "$capture"        || args_ok=false
-    grep -qF "logLevel: ${SMOKE_LOG_LEVEL}" "$capture"     || args_ok=false
-    grep -qF "customerUserId: ${SMOKE_USER_ID}" "$capture" || args_ok=false
-    if [[ "$args_ok" == true ]]; then
-      log "Arg check OK: native bridge received apiKey/logLevel/customerUserId as sent"
-    else
-      grep -F "configure called with" "$capture" | head -3 >&2 || true
-      rm -f "$capture"
-      fail "Value check FAILED: configure args did not reach native as sent"
-    fi
     rm -f "$capture"
     return 0
   fi

--- a/ios/AppstackBridge.h
+++ b/ios/AppstackBridge.h
@@ -12,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AppstackBridge : NSObject
 
 + (void)configureWithApiKey:(NSString *)apiKey
-            endpointBaseUrl:(NSString * _Nullable)endpointBaseUrl
                    logLevel:(NSInteger)logLevel
              customerUserId:(NSString * _Nullable)customerUserId;
 

--- a/ios/AppstackBridge.h
+++ b/ios/AppstackBridge.h
@@ -12,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AppstackBridge : NSObject
 
 + (void)configureWithApiKey:(NSString *)apiKey
-                    isDebug:(BOOL)isDebug
             endpointBaseUrl:(NSString * _Nullable)endpointBaseUrl
                    logLevel:(NSInteger)logLevel
              customerUserId:(NSString * _Nullable)customerUserId;

--- a/ios/AppstackBridge.swift
+++ b/ios/AppstackBridge.swift
@@ -11,17 +11,19 @@ public class AppstackBridge: NSObject {
     private static let wrapperVersion = "react-native-1.0.0"
 
     @objc public static func configure(apiKey: String, isDebug: Bool, endpointBaseUrl: String?, logLevel: Int, customerUserId: String?) {
-        // Convert Int logLevel to LogLevel enum
+        // Translate the JS-side logLevel contract (0=DEBUG, 1=INFO, 2=WARN, 3=ERROR;
+        // verbosity descending) into the native LogLevel enum (off/error/info/debug;
+        // verbosity ascending). This keeps iOS consistent with Android and with the
+        // documented JS values. iOS has no dedicated WARN tier, so WARN folds down to
+        // .error — quieter than INFO, and there are no warn-level logs on iOS to lose.
         let logLevelEnum: LogLevel
         switch logLevel {
         case 0:
-            logLevelEnum = .off
-        case 1:
-            logLevelEnum = .error
-        case 2:
             logLevelEnum = .debug
-        case 3:
+        case 1:
             logLevelEnum = .info
+        case 2, 3:
+            logLevelEnum = .error
         default:
             logLevelEnum = .info
         }

--- a/ios/AppstackBridge.swift
+++ b/ios/AppstackBridge.swift
@@ -28,6 +28,17 @@ public class AppstackBridge: NSObject {
             logLevelEnum = .info
         }
         
+        // Testing-only proxy override, read from the app's Info.plist. This is NOT
+        // exposed through the public configure() API: a proxy URL is applied only if
+        // the host app deliberately ships an APPSTACK_DEV_PROXY_URL key (this repo's
+        // homepage-app does; published-package consumers do not). Routed through the
+        // SDK's @_spi setProxyUrl(_:) hook and applied before configure so the SDK's
+        // initial requests target it.
+        if let devProxyUrl = (Bundle.main.object(forInfoDictionaryKey: "APPSTACK_DEV_PROXY_URL") as? String)
+            .flatMap({ $0.isEmpty ? nil : $0 }) {
+            AppstackAttributionSdk.shared.setProxyUrl(devProxyUrl)
+        }
+
         AppstackAttributionSdk.shared.configure(
             apiKey: apiKey,
             logLevel: logLevelEnum,

--- a/ios/AppstackBridge.swift
+++ b/ios/AppstackBridge.swift
@@ -10,7 +10,7 @@ public class AppstackBridge: NSObject {
 
     private static let wrapperVersion = "react-native-1.0.0"
 
-    @objc public static func configure(apiKey: String, isDebug: Bool, endpointBaseUrl: String?, logLevel: Int, customerUserId: String?) {
+    @objc public static func configure(apiKey: String, endpointBaseUrl: String?, logLevel: Int, customerUserId: String?) {
         // Translate the JS-side logLevel contract (0=DEBUG, 1=INFO, 2=WARN, 3=ERROR;
         // verbosity descending) into the native LogLevel enum (off/error/info/debug;
         // verbosity ascending). This keeps iOS consistent with Android and with the

--- a/ios/AppstackBridge.swift
+++ b/ios/AppstackBridge.swift
@@ -10,7 +10,7 @@ public class AppstackBridge: NSObject {
 
     private static let wrapperVersion = "react-native-1.0.0"
 
-    @objc public static func configure(apiKey: String, endpointBaseUrl: String?, logLevel: Int, customerUserId: String?) {
+    @objc public static func configure(apiKey: String, logLevel: Int, customerUserId: String?) {
         // Translate the JS-side logLevel contract (0=DEBUG, 1=INFO, 2=WARN, 3=ERROR;
         // verbosity descending) into the native LogLevel enum (off/error/info/debug;
         // verbosity ascending). This keeps iOS consistent with Android and with the

--- a/ios/AppstackReactNative.mm
+++ b/ios/AppstackReactNative.mm
@@ -25,14 +25,11 @@ RCT_EXPORT_METHOD(configure:(NSString *)apiKey
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-    NSLog(@"[AppstackReactNative] configure called with apiKey: %@, isDebug: %@, endpointBaseUrl: %@, logLevel: %ld, customerUserId: %@", apiKey, isDebug ? @"YES" : @"NO", endpointBaseUrl ?: @"nil", (long)logLevel, customerUserId ?: @"nil");
-    
     if (!apiKey || [apiKey length] == 0) {
-        NSLog(@"[AppstackReactNative] configure failed: Invalid API key");
         reject(@"INVALID_API_KEY", @"API key cannot be null or empty", nil);
         return;
     }
-    
+
     dispatch_async(dispatch_get_main_queue(), ^{
         @try {
             // Call the Swift bridge method directly
@@ -40,7 +37,6 @@ RCT_EXPORT_METHOD(configure:(NSString *)apiKey
 
             resolve(@(YES));
         } @catch (NSException *exception) {
-            NSLog(@"[AppstackReactNative] configure failed with exception: %@", exception.reason);
             reject(@"CONFIGURATION_ERROR", exception.reason, nil);
         }
     });
@@ -54,41 +50,35 @@ RCT_EXPORT_METHOD(sendEvent:(NSString *)eventType
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-    NSLog(@"[AppstackReactNative] sendEvent called with eventType: %@, eventName: %@, parameters: %@", eventType, eventName, parameters);
-    
     // At least one of eventName or eventType should be provided
     if ((!eventName || [eventName length] == 0) && (!eventType || [eventType length] == 0)) {
-        NSLog(@"[AppstackReactNative] sendEvent failed: Both eventName and eventType are empty");
         reject(@"INVALID_EVENT_NAME", @"Either eventName or eventType must be provided", nil);
         return;
     }
-    
+
     // If eventType is CUSTOM, eventName is required
     if (eventType && [eventType length] > 0 && [eventType.uppercaseString isEqualToString:@"CUSTOM"]) {
         if (!eventName || [eventName length] == 0) {
-            NSLog(@"[AppstackReactNative] sendEvent failed: eventName is required when eventType is CUSTOM");
             reject(@"INVALID_EVENT_NAME", @"eventName is required when eventType is CUSTOM", nil);
             return;
         }
     }
-    
+
     @try {
-        // Convert parameters: handle NSNull by converting to nil
+        // Convert parameters: handle NSNull by converting to nil.
+        // Non-dictionary parameters are ignored.
         NSDictionary *parametersDict = nil;
         if (parameters != nil && parameters != [NSNull null]) {
             if ([parameters isKindOfClass:[NSDictionary class]]) {
                 parametersDict = (NSDictionary *)parameters;
-            } else {
-                NSLog(@"[AppstackReactNative] Warning: parameters is not a dictionary, ignoring");
             }
         }
-        
+
         // Call the Swift bridge method directly with parameters
         [AppstackBridge sendEvent:eventType eventName:eventName parameters:parametersDict];
 
         resolve(@(YES));
     } @catch (NSException *exception) {
-        NSLog(@"[AppstackReactNative] sendEvent failed with exception: %@", exception.reason);
         reject(@"EVENT_SEND_ERROR", exception.reason, nil);
     }
 }
@@ -105,11 +95,9 @@ RCT_EXPORT_METHOD(enableAppleAdsAttribution:(RCTPromiseResolveBlock)resolve
 
             resolve(@(YES));
         } @catch (NSException *exception) {
-            NSLog(@"[AppstackReactNative] enableAppleAdsAttribution failed with exception: %@", exception.reason);
             reject(@"ASA_ATTRIBUTION_ERROR", exception.reason, nil);
         }
     } else {
-        NSLog(@"[AppstackReactNative] ERROR: iOS version < 15.0, Apple Ads Attribution not supported");
         reject(@"UNSUPPORTED_IOS_VERSION", @"Apple Ads Attribution requires iOS 15.0 or later", nil);
     }
 }
@@ -126,11 +114,9 @@ RCT_EXPORT_METHOD(disableASAAttributionTracking:(RCTPromiseResolveBlock)resolve
 
             resolve(@(YES));
         } @catch (NSException *exception) {
-            NSLog(@"[AppstackReactNative] disableASAAttributionTracking failed with exception: %@", exception.reason);
             reject(@"ASA_DISABLE_ERROR", exception.reason, nil);
         }
     } else {
-        NSLog(@"[AppstackReactNative] ERROR: iOS version < 15.0, Apple Ads Attribution not supported");
         reject(@"UNSUPPORTED_IOS_VERSION", @"Apple Ads Attribution requires iOS 15.0 or later", nil);
     }
 }
@@ -142,11 +128,8 @@ RCT_EXPORT_METHOD(getAppstackId:(RCTPromiseResolveBlock)resolve
         // Call the Swift bridge method directly
         NSString *appstackId = [AppstackBridge getAppstackId];
 
-        NSLog(@"[AppstackReactNative] getAppstackId method called successfully via bridge, ID: %@", appstackId);
-
         resolve(appstackId);
     } @catch (NSException *exception) {
-        NSLog(@"[AppstackReactNative] getAppstackId failed with exception: %@", exception.reason);
         reject(@"GET_APPSTACK_ID_ERROR", exception.reason, nil);
     }
 }
@@ -160,7 +143,6 @@ RCT_EXPORT_METHOD(isSdkDisabled:(RCTPromiseResolveBlock)resolve
 
         resolve(@(isDisabled));
     } @catch (NSException *exception) {
-        NSLog(@"[AppstackReactNative] isDisabled failed with exception: %@", exception.reason);
         reject(@"STATUS_ERROR", exception.reason, nil);
     }
 }
@@ -172,18 +154,15 @@ RCT_EXPORT_METHOD(getAttributionParams:(RCTPromiseResolveBlock)resolve
         [AppstackBridge getAttributionParamsWithCompletion:^(NSDictionary * _Nullable params, NSError * _Nullable error) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (error != nil) {
-                    NSLog(@"[AppstackReactNative] getAttributionParams failed with error: %@", error.localizedDescription);
                     reject(@"ATTRIBUTION_PARAMS_ERROR", error.localizedDescription, error);
                     return;
                 }
 
                 NSDictionary *safeParams = params ?: @{};
-                NSLog(@"[AppstackReactNative] getAttributionParams completed successfully via bridge, params: %@", safeParams);
                 resolve(safeParams);
             });
         }];
     } @catch (NSException *exception) {
-        NSLog(@"[AppstackReactNative] getAttributionParams failed with exception: %@", exception.reason);
         reject(@"ATTRIBUTION_PARAMS_ERROR", exception.reason, nil);
     }
 }

--- a/ios/AppstackReactNative.mm
+++ b/ios/AppstackReactNative.mm
@@ -18,7 +18,6 @@ RCT_EXPORT_MODULE()
 #pragma mark - SDK Configuration
 
 RCT_EXPORT_METHOD(configure:(NSString *)apiKey
-                 endpointBaseUrl:(NSString * _Nullable)endpointBaseUrl
                  logLevel:(NSInteger)logLevel
                  customerUserId:(NSString * _Nullable)customerUserId
                  resolver:(RCTPromiseResolveBlock)resolve
@@ -32,7 +31,7 @@ RCT_EXPORT_METHOD(configure:(NSString *)apiKey
     dispatch_async(dispatch_get_main_queue(), ^{
         @try {
             // Call the Swift bridge method directly
-            [AppstackBridge configureWithApiKey:apiKey endpointBaseUrl:endpointBaseUrl logLevel:logLevel customerUserId:customerUserId];
+            [AppstackBridge configureWithApiKey:apiKey logLevel:logLevel customerUserId:customerUserId];
 
             resolve(@(YES));
         } @catch (NSException *exception) {

--- a/ios/AppstackReactNative.mm
+++ b/ios/AppstackReactNative.mm
@@ -35,14 +35,9 @@ RCT_EXPORT_METHOD(configure:(NSString *)apiKey
     
     dispatch_async(dispatch_get_main_queue(), ^{
         @try {
-            NSLog(@"[AppstackReactNative] Calling AppstackBridge.configure directly...");
-            
             // Call the Swift bridge method directly
             [AppstackBridge configureWithApiKey:apiKey isDebug:isDebug endpointBaseUrl:endpointBaseUrl logLevel:logLevel customerUserId:customerUserId];
-            
-            NSLog(@"[AppstackReactNative] configure method called successfully via bridge");
-            
-            NSLog(@"[AppstackReactNative] configure completed, resolving promise");
+
             resolve(@(YES));
         } @catch (NSException *exception) {
             NSLog(@"[AppstackReactNative] configure failed with exception: %@", exception.reason);
@@ -88,14 +83,9 @@ RCT_EXPORT_METHOD(sendEvent:(NSString *)eventType
             }
         }
         
-        NSLog(@"[AppstackReactNative] Calling AppstackBridge.sendEvent directly...");
-        
         // Call the Swift bridge method directly with parameters
         [AppstackBridge sendEvent:eventType eventName:eventName parameters:parametersDict];
-        
-        NSLog(@"[AppstackReactNative] sendEvent method called successfully via bridge");
-        
-        NSLog(@"[AppstackReactNative] sendEvent completed, resolving promise");
+
         resolve(@(YES));
     } @catch (NSException *exception) {
         NSLog(@"[AppstackReactNative] sendEvent failed with exception: %@", exception.reason);
@@ -108,19 +98,11 @@ RCT_EXPORT_METHOD(sendEvent:(NSString *)eventType
 RCT_EXPORT_METHOD(enableAppleAdsAttribution:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-    NSLog(@"[AppstackReactNative] enableAppleAdsAttribution called");
-    
     if (@available(iOS 15.0, *)) {
-        NSLog(@"[AppstackReactNative] iOS 15.0+ detected, proceeding with Apple Ads Attribution");
         @try {
-            NSLog(@"[AppstackReactNative] Calling AppstackBridge.enableAppleAdsAttribution directly...");
-            
             // Call the Swift bridge method directly
             [AppstackBridge enableAppleAdsAttribution];
-            
-            NSLog(@"[AppstackReactNative] enableAppleAdsAttribution method called successfully via bridge");
-            
-            NSLog(@"[AppstackReactNative] enableAppleAdsAttribution completed, resolving promise");
+
             resolve(@(YES));
         } @catch (NSException *exception) {
             NSLog(@"[AppstackReactNative] enableAppleAdsAttribution failed with exception: %@", exception.reason);
@@ -137,19 +119,11 @@ RCT_EXPORT_METHOD(enableAppleAdsAttribution:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(disableASAAttributionTracking:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-    NSLog(@"[AppstackReactNative] disableASAAttributionTracking called");
-    
     if (@available(iOS 15.0, *)) {
-        NSLog(@"[AppstackReactNative] iOS 15.0+ detected, proceeding with disable ASA Attribution");
         @try {
-            NSLog(@"[AppstackReactNative] Calling AppstackBridge.disableASAAttributionTracking directly...");
-            
             // Call the Swift bridge method directly
             [AppstackBridge disableASAAttributionTracking];
-            
-            NSLog(@"[AppstackReactNative] disableASAAttributionTracking method called successfully via bridge");
-            
-            NSLog(@"[AppstackReactNative] disableASAAttributionTracking completed, resolving promise");
+
             resolve(@(YES));
         } @catch (NSException *exception) {
             NSLog(@"[AppstackReactNative] disableASAAttributionTracking failed with exception: %@", exception.reason);
@@ -164,17 +138,12 @@ RCT_EXPORT_METHOD(disableASAAttributionTracking:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(getAppstackId:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-    NSLog(@"[AppstackReactNative] getAppstackId called");
-
     @try {
-        NSLog(@"[AppstackReactNative] Calling AppstackBridge.getAppstackId directly...");
-
         // Call the Swift bridge method directly
         NSString *appstackId = [AppstackBridge getAppstackId];
 
         NSLog(@"[AppstackReactNative] getAppstackId method called successfully via bridge, ID: %@", appstackId);
 
-        NSLog(@"[AppstackReactNative] getAppstackId completed, resolving promise");
         resolve(appstackId);
     } @catch (NSException *exception) {
         NSLog(@"[AppstackReactNative] getAppstackId failed with exception: %@", exception.reason);
@@ -185,17 +154,10 @@ RCT_EXPORT_METHOD(getAppstackId:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(isSdkDisabled:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-    NSLog(@"[AppstackReactNative] isSdkDisabled called");
-
     @try {
-        NSLog(@"[AppstackReactNative] Calling AppstackBridge.isSdkDisabled directly...");
-
         // Call the Swift bridge method directly
         BOOL isDisabled = [AppstackBridge isSdkDisabled];
 
-        NSLog(@"[AppstackReactNative] isDisabled method called successfully via bridge, disabled: %@", isDisabled ? @"YES" : @"NO");
-
-        NSLog(@"[AppstackReactNative] isDisabled completed, resolving promise");
         resolve(@(isDisabled));
     } @catch (NSException *exception) {
         NSLog(@"[AppstackReactNative] isDisabled failed with exception: %@", exception.reason);
@@ -206,11 +168,7 @@ RCT_EXPORT_METHOD(isSdkDisabled:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(getAttributionParams:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-    NSLog(@"[AppstackReactNative] getAttributionParams called");
-
     @try {
-        NSLog(@"[AppstackReactNative] Calling AppstackBridge.getAttributionParams asynchronously...");
-
         [AppstackBridge getAttributionParamsWithCompletion:^(NSDictionary * _Nullable params, NSError * _Nullable error) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (error != nil) {

--- a/ios/AppstackReactNative.mm
+++ b/ios/AppstackReactNative.mm
@@ -18,7 +18,6 @@ RCT_EXPORT_MODULE()
 #pragma mark - SDK Configuration
 
 RCT_EXPORT_METHOD(configure:(NSString *)apiKey
-                 isDebug:(BOOL)isDebug
                  endpointBaseUrl:(NSString * _Nullable)endpointBaseUrl
                  logLevel:(NSInteger)logLevel
                  customerUserId:(NSString * _Nullable)customerUserId
@@ -33,7 +32,7 @@ RCT_EXPORT_METHOD(configure:(NSString *)apiKey
     dispatch_async(dispatch_get_main_queue(), ^{
         @try {
             // Call the Swift bridge method directly
-            [AppstackBridge configureWithApiKey:apiKey isDebug:isDebug endpointBaseUrl:endpointBaseUrl logLevel:logLevel customerUserId:customerUserId];
+            [AppstackBridge configureWithApiKey:apiKey endpointBaseUrl:endpointBaseUrl logLevel:logLevel customerUserId:customerUserId];
 
             resolve(@(YES));
         } @catch (NSException *exception) {

--- a/src/NativeAppstackReactNative.ts
+++ b/src/NativeAppstackReactNative.ts
@@ -4,7 +4,6 @@ import { TurboModuleRegistry, NativeModules } from 'react-native';
 export interface Spec extends TurboModule {
   configure(
     apiKey: string,
-    isDebug?: boolean,
     endpointBaseUrl?: string,
     logLevel?: number,
     customerUserId?: string | null

--- a/src/NativeAppstackReactNative.ts
+++ b/src/NativeAppstackReactNative.ts
@@ -2,12 +2,7 @@ import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry, NativeModules } from 'react-native';
 
 export interface Spec extends TurboModule {
-  configure(
-    apiKey: string,
-    endpointBaseUrl?: string,
-    logLevel?: number,
-    customerUserId?: string | null
-  ): Promise<boolean>;
+  configure(apiKey: string, logLevel?: number, customerUserId?: string | null): Promise<boolean>;
   sendEvent(
     eventType: string | null,
     eventName: string | null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export interface AppstackSDKInterface {
   /**
    * Configure Appstack SDK with your API key and optional parameters
    * @param apiKey - Your Appstack API key obtained from the dashboard
-   * @param isDebug - Enable debug mode (optional, default false)
+   * @param isDebug - Deprecated and ignored; use `logLevel` instead. Still accepted for backward compatibility (optional, default false)
    * @param endpointBaseUrl - Custom endpoint base URL (optional)
    * @param logLevel - Log level: 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR (optional, default 1)
    * @param customerUserId - Optional customer user ID to associate with the device/session
@@ -159,9 +159,10 @@ class AppstackSDK implements AppstackSDKInterface {
     }
 
     try {
+      // isDebug is accepted for backward compatibility but no longer forwarded to
+      // native — the underlying SDKs dropped debug mode in favor of logLevel.
       const result = await AppstackReactNative.configure(
         apiKey.trim(),
-        isDebug,
         endpointBaseUrl?.trim() || null,
         logLevel,
         customerUserId != null ? customerUserId.trim() || null : null

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export interface AppstackSDKInterface {
    * Configure Appstack SDK with your API key and optional parameters
    * @param apiKey - Your Appstack API key obtained from the dashboard
    * @param isDebug - Deprecated and ignored; use `logLevel` instead. Still accepted for backward compatibility (optional, default false)
-   * @param endpointBaseUrl - Custom endpoint base URL (optional)
+   * @param endpointBaseUrl - Deprecated and ignored; not forwarded to native. Still accepted for backward compatibility (optional)
    * @param logLevel - Log level: 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR (optional, default 1)
    * @param customerUserId - Optional customer user ID to associate with the device/session
    * @returns Promise that resolves when configuration is successful
@@ -159,11 +159,11 @@ class AppstackSDK implements AppstackSDKInterface {
     }
 
     try {
-      // isDebug is accepted for backward compatibility but no longer forwarded to
-      // native — the underlying SDKs dropped debug mode in favor of logLevel.
+      // isDebug and endpointBaseUrl are accepted for backward compatibility but no
+      // longer forwarded to native: isDebug was dropped in favor of logLevel, and a
+      // custom endpoint is not wired through the RN wrapper.
       const result = await AppstackReactNative.configure(
         apiKey.trim(),
-        endpointBaseUrl?.trim() || null,
         logLevel,
         customerUserId != null ? customerUserId.trim() || null : null
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,7 @@ export interface AppstackConfig {
   isDebug?: boolean;
 
   /**
-   * Custom endpoint base URL (optional)
+   * @deprecated Ignored by the RN wrapper (not forwarded to native). Still accepted for backward compatibility.
    */
   endpointBaseUrl?: string;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,7 @@ export interface AppstackConfig {
   apiKey: string;
 
   /**
-   * Enable debug logs (optional, default false)
+   * @deprecated Ignored; use `logLevel` instead. Still accepted for backward compatibility.
    */
   isDebug?: boolean;
 


### PR DESCRIPTION
## Summary

Cleans up the native bridge layer: removes leftover debug logging that wrote sensitive values to device logs, aligns `logLevel` behaviour across iOS/Android, stops forwarding deprecated parameters to native, and adds an internal-only dev-endpoint hook for the example app.

## Motivation

A PR review noted that the iOS bridge logs weren't redacted (contrary to assumption). Auditing the bridge turned up unconditional `NSLog`/`Log.d` calls — active in release builds — that wrote the raw `apiKey`, `customerUserId`, event parameters, and attribution params to the host app's device logs. These were leftover bring-up/debug logs with no production value. Rather than redact/gate them, we delegate all device logging to the underlying native SDKs, which already have a mature, level-gated, sanitized logger.

## Changes

### Logging
- **Removed all device logging from the RN bridge** (iOS `NSLog`, Android `Log.d`/`Log.e`). Device logs are now emitted solely by the native `AppstackSDK` logger (level-gated + sanitized); developer-facing errors continue to surface via `promise.reject` → JS `console.error`.
- The bridge no longer writes the apiKey, customerUserId, or event parameters to device logs.

### `logLevel` consistency
- Fixed the **iOS `logLevel` mapping**, which was inverted relative to the documented JS contract (`0=DEBUG … 3=ERROR`). Previously `0` mapped to `.off` (silent) on iOS; now `0→.debug`, `1→.info`, `2/3→.error`, matching Android and the JS docs. iOS has no dedicated `WARN` tier, so `WARN` folds to `.error`.

### Deprecated parameters
- **`isDebug`** and **`endpointBaseUrl`** are still accepted (and validated) by the public JS `configure()` for backward compatibility, but are **no longer forwarded to native** — `isDebug` was superseded by `logLevel`, and custom endpoints aren't supported through the wrapper by design. Both are marked `@deprecated`. The native bridge signatures dropped them (`configure(apiKey, logLevel, customerUserId)`).
- Removed unused methods from the Android module.

### Example app (dev environment)
- Added an internal-only `setProxyUrl` hook: the bridge reads an `APPSTACK_DEV_PROXY_URL` native manifest key (Info.plist / AndroidManifest) and, if present, points the SDK at it **before** `configure`. This mirrors the Flutter plugin. The key is injected only in the example app via a repo-only Expo config plugin, so **published-package consumers never ship it** and always hit production.

## Tests
- Updated `__tests__/AppstackSDK.test.ts` for the new native `configure` arity (kept the JS-side `isDebug`/`endpointBaseUrl` validation tests).
- Updated `integration-tests/run.sh`: dropped the log-scraping value-marshaling assertions (the bridge no longer logs) and rely on the JS round-trip sentinel (`APPSTACK_SMOKE_OK` + a real `getAppstackId` UUID) as the authoritative signal.
- `tsc`, `eslint`, and jest (all suites) pass. iOS runtime-verified: `logLevel` mapping and the dev-proxy hook confirmed on the simulator.

## Notes
- Not a breaking change for integrators: the public JS `configure()` signature is unchanged.
- Follow-up (separate PR): migrate the example app to Expo CNG (gitignore generated `ios/`/`android/`), keeping config in `app.json` + the config plugin.