### PR TITLE
Update native SDKs to latest stable (iOS 4.4.0, Android 1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the React Native Appstack SDK will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-07-21
+
+### Changed
+- **iOS:** Updated `AppstackSDK.xcframework` to `4.4.0`. Adds Mac Catalyst support to the prebuilt XCFramework and improves install detection and attribution reliability.
+- **Android:** Updated the native Appstack Android SDK dependency to `1.5.0`.
+
 ## [2.3.0] - 2026-06-24
 
 ### Changed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,7 +88,7 @@ repositories {
 dependencies {
     compileOnly 'com.facebook.react:react-native:+'
 
-    implementation 'tech.appstack.android-sdk:appstack-android-sdk:1.5.0-rc0'
+    implementation 'tech.appstack.android-sdk:appstack-android-sdk:1.5.0'
 
     implementation 'androidx.annotation:annotation:1.7.1'
 


### PR DESCRIPTION
## Summary
Move both native SDKs off release candidates and onto their latest **stable** versions, and record the change in the changelog for the upcoming `2.4.0` release.

- **iOS:** `AppstackSDK.xcframework` → stable **4.4.0** (already landed on `main` via `7635a93`; verified byte-identical to the official `ios-appstack-sdk` 4.4.0 release asset — all slices + signatures match).
- **Android:** `tech.appstack.android-sdk:appstack-android-sdk` → **`1.5.0`** (was `1.5.0-rc0`). Confirmed as Maven Central's `<latest>`/`<release>`.
- **CHANGELOG:** added the `## [2.4.0]` entry covering both updates.

## Validation
- Full recursive diff of the vendored iOS framework vs the official 4.4.0 release asset → identical.
- `1.5.0` present on Maven Central as the stable release (RCs rc0–rc3 superseded).
- Repo-wide scan: no remaining `-rc` version pins; example app has no independent native-SDK pin.

## Release notes / follow-up
- This unblocks re-cutting `2.4.0`. The old `2.4.0` tag (which pointed at a pre-fix commit with the RC framework) has been deleted; after this merges, the tag should be re-created on the merge commit to trigger the gated stable publish.