### PR TITLE
Add hermetic Expo integration checks and release gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,17 +18,18 @@ env:
   SEMVER_REGEX: '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
 
 jobs:
-  # Stable releases must pass integration tests first; -rc tags skip them
-  # so untested versions can still be published under the 'rc' dist-tag.
-  integration-tests:
-    if: ${{ !contains(github.ref_name, '-rc') }}
+  # RC releases run the package and latest-SDK runtime checks. Stable releases
+  # additionally run the complete compatibility build matrix.
+  release-checks:
+    name: ${{ contains(github.ref_name, '-rc') && 'RC checks' || 'Stable checks' }}
     uses: ./.github/workflows/integration-tests.yml
+    with:
+      run-compatibility-matrix: ${{ !contains(github.ref_name, '-rc') }}
 
   # Build and publish on version tags
   publish:
     runs-on: ubuntu-latest
-    needs: [integration-tests]
-    if: ${{ always() && (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped') }}
+    needs: [release-checks]
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,17 +1,42 @@
 name: Integration Tests
 
-# Only callable: PRs trigger this via tests.yml (which displays all jobs
-# under a single "tests /" group), and build.yml calls it before stable
-# publishes. Concurrency/cancellation is handled by the callers.
+# Only callable: tests.yml uses focused checks for PRs and configurable checks
+# for manual runs, while build.yml uses focused checks for RC tags and full
+# checks for stable tags. Concurrency/cancellation is handled by the callers.
 on:
   workflow_call:
+    inputs:
+      run-compatibility-matrix:
+        description: Run the older-SDK, legacy-architecture, and static-framework build matrix
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
 
 jobs:
+  package:
+    name: Build checks / JavaScript package
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Lint, typecheck, test, and build package
+        run: ./build.sh --ci --clean
+
   android:
-    name: Android (Expo SDK ${{ matrix.expo-sdk }}, ${{ matrix.architecture }} architecture)
+    name: Build checks / Android (Expo SDK ${{ matrix.expo-sdk }}, ${{ matrix.architecture }} architecture)
+    needs: package
+    if: ${{ inputs.run-compatibility-matrix }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -48,7 +73,9 @@ jobs:
           --architecture ${{ matrix.architecture }}
 
   ios:
-    name: iOS (Expo SDK ${{ matrix.expo-sdk }}, ${{ matrix.architecture }} architecture, ${{ matrix.frameworks }} frameworks, Xcode ${{ matrix.xcode }})
+    name: Build checks / iOS (Expo SDK ${{ matrix.expo-sdk }}, ${{ matrix.architecture }} architecture, ${{ matrix.frameworks }} frameworks, Xcode ${{ matrix.xcode }})
+    needs: package
+    if: ${{ inputs.run-compatibility-matrix }}
     runs-on: macos-26
     timeout-minutes: 90
     strategy:
@@ -110,7 +137,8 @@ jobs:
   # the latest Expo SDK only to keep the matrix lean. Emulator needs KVM, which
   # the standard (free) ubuntu-latest runner provides.
   android-smoke:
-    name: Android runtime smoke (Expo SDK 57)
+    name: Runtime checks / Android (Expo SDK 57)
+    needs: package
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -148,7 +176,8 @@ jobs:
   # iOS counterpart of android-smoke: boots a simulator, launches the app, and
   # asserts the same JS -> bridge -> native round trip. Standard macOS runner.
   ios-smoke:
-    name: iOS runtime smoke (Expo SDK 57)
+    name: Runtime checks / iOS (Expo SDK 57)
+    needs: package
     runs-on: macos-26
     timeout-minutes: 90
     steps:
@@ -177,13 +206,28 @@ jobs:
   tests:
     name: Integration tests
     runs-on: ubuntu-latest
-    needs: [android, ios, android-smoke, ios-smoke]
+    needs: [package, android, ios, android-smoke, ios-smoke]
     if: ${{ always() }}
     steps:
-      - name: Check matrix results
+      - name: Check required results
         run: |
-          if [[ "${{ needs.android.result }}" != "success" || "${{ needs.ios.result }}" != "success" || "${{ needs['android-smoke'].result }}" != "success" || "${{ needs['ios-smoke'].result }}" != "success" ]]; then
-            echo "❌ Android: ${{ needs.android.result }}, iOS: ${{ needs.ios.result }}, Android smoke: ${{ needs['android-smoke'].result }}, iOS smoke: ${{ needs['ios-smoke'].result }}"
+          set -euo pipefail
+
+          if [[ "${{ needs.package.result }}" != "success" || "${{ needs['android-smoke'].result }}" != "success" || "${{ needs['ios-smoke'].result }}" != "success" ]]; then
+            echo "❌ Package: ${{ needs.package.result }}, Android runtime: ${{ needs['android-smoke'].result }}, iOS runtime: ${{ needs['ios-smoke'].result }}"
             exit 1
           fi
-          echo "✅ All integration tests passed"
+
+          if [[ "${{ inputs.run-compatibility-matrix }}" == "true" ]]; then
+            if [[ "${{ needs.android.result }}" != "success" || "${{ needs.ios.result }}" != "success" ]]; then
+              echo "❌ Android compatibility: ${{ needs.android.result }}, iOS compatibility: ${{ needs.ios.result }}"
+              exit 1
+            fi
+            echo "✅ Full checks passed"
+          else
+            if [[ "${{ needs.android.result }}" != "skipped" || "${{ needs.ios.result }}" != "skipped" ]]; then
+              echo "❌ Compatibility jobs should be skipped for focused checks: Android=${{ needs.android.result }}, iOS=${{ needs.ios.result }}"
+              exit 1
+            fi
+            echo "✅ Focused checks passed"
+          fi

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   android:
-    name: Android (Expo SDK ${{ matrix.expo-sdk }})
+    name: Android (Expo SDK ${{ matrix.expo-sdk }}, ${{ matrix.architecture }} architecture)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -19,6 +19,12 @@ jobs:
       matrix:
         # Keep in sync with the ios job's expo-sdk list below
         expo-sdk: ['54', '55', '56']
+        architecture: ['new']
+        include:
+          # Expo SDK 54 is the compatibility boundary that still supports
+          # explicitly opting out of React Native's New Architecture.
+          - expo-sdk: '54'
+            architecture: 'legacy'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -37,10 +43,12 @@ jobs:
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Run integration test
-        run: ./integration-tests/run.sh ${{ matrix.expo-sdk }}
+        run: >
+          ./integration-tests/run.sh ${{ matrix.expo-sdk }}
+          --architecture ${{ matrix.architecture }}
 
   ios:
-    name: iOS (Expo SDK ${{ matrix.expo-sdk }}, ${{ matrix.frameworks }} frameworks)
+    name: iOS (Expo SDK ${{ matrix.expo-sdk }}, ${{ matrix.architecture }} architecture, ${{ matrix.frameworks }} frameworks, Xcode ${{ matrix.xcode }})
     runs-on: macos-26
     timeout-minutes: 90
     strategy:
@@ -48,13 +56,24 @@ jobs:
       matrix:
         # Keep in sync with the android job's expo-sdk list above
         expo-sdk: ['54', '55', '56']
+        architecture: ['new']
         frameworks: ['default']
+        xcode: ['default']
         include:
           # Static frameworks exercise different header search paths
           # (common setup in apps using Firebase and similar pods).
           # Runs only against the latest SDK to keep the matrix lean.
           - expo-sdk: '56'
+            architecture: 'new'
             frameworks: 'static'
+            xcode: 'default'
+          # Keep the last supported legacy-architecture boundary on the exact
+          # store-era toolchain validated manually, rather than the image's
+          # rolling default Xcode.
+          - expo-sdk: '54'
+            architecture: 'legacy'
+            frameworks: 'default'
+            xcode: '26.2'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -65,9 +84,24 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Select and verify Xcode 26.2
+        if: ${{ matrix.xcode == '26.2' }}
+        run: |
+          set -euo pipefail
+          XCODE_DEVELOPER_DIR=/Applications/Xcode_26.2.app/Contents/Developer
+          test -d "$XCODE_DEVELOPER_DIR"
+          XCODE_VERSION="$(DEVELOPER_DIR="$XCODE_DEVELOPER_DIR" xcodebuild -version | sed -n '1p')"
+          test "$XCODE_VERSION" = "Xcode 26.2"
+          echo "DEVELOPER_DIR=$XCODE_DEVELOPER_DIR" >> "$GITHUB_ENV"
+          echo "Selected $XCODE_VERSION"
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
       - name: Run integration test
         run: >
           ./integration-tests/run.sh ${{ matrix.expo-sdk }} --platform ios
+          --architecture ${{ matrix.architecture }}
           ${{ matrix.frameworks == 'static' && '--static-frameworks' || '' }}
 
   # Runtime smoke: unlike the build-only jobs above, this launches the app on an
@@ -109,7 +143,7 @@ jobs:
           arch: x86_64
           target: default
           disable-animations: true
-          script: ./integration-tests/run.sh 57 --platform android --smoke
+          script: ./integration-tests/run.sh 57 --platform android --architecture new --smoke
 
   # iOS counterpart of android-smoke: boots a simulator, launches the app, and
   # asserts the same JS -> bridge -> native round trip. Standard macOS runner.
@@ -135,7 +169,7 @@ jobs:
           xcrun simctl boot "$DEVICE_ID" || true
 
       - name: Run iOS runtime smoke
-        run: ./integration-tests/run.sh 57 --platform ios --smoke
+        run: ./integration-tests/run.sh 57 --platform ios --architecture new --smoke
 
   # Single aggregate check that summarizes the whole matrix. Point branch
   # protection at this job only — new matrix entries are then covered

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -131,11 +131,10 @@ jobs:
           --architecture ${{ matrix.architecture }}
           ${{ matrix.frameworks == 'static' && '--static-frameworks' || '' }}
 
-  # Runtime smoke: unlike the build-only jobs above, this launches the app on an
-  # emulator and asserts the JS -> bridge -> native SDK round trip actually works
-  # (catches bridge-registration / crash-on-init bugs a compile can't). Gated to
-  # the latest Expo SDK only to keep the matrix lean. Emulator needs KVM, which
-  # the standard (free) ubuntu-latest runner provides.
+  # Runtime checks launch the app against a loopback-only recording backend and
+  # validate the public JS API, bridge, real native SDK, and emitted requests.
+  # They use the latest Expo SDK only to keep the matrix lean. The Android
+  # emulator needs KVM, which the standard (free) ubuntu-latest runner provides.
   android-smoke:
     name: Runtime checks / Android (Expo SDK 57)
     needs: package
@@ -164,7 +163,7 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Run Android runtime smoke
+      - name: Run Android runtime check
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.34.0
         with:
           api-level: 30
@@ -173,8 +172,7 @@ jobs:
           disable-animations: true
           script: ./integration-tests/run.sh 57 --platform android --architecture new --smoke
 
-  # iOS counterpart of android-smoke: boots a simulator, launches the app, and
-  # asserts the same JS -> bridge -> native round trip. Standard macOS runner.
+  # iOS counterpart: boots a simulator and validates the same hermetic contract.
   ios-smoke:
     name: Runtime checks / iOS (Expo SDK 57)
     needs: package
@@ -197,7 +195,7 @@ jobs:
           echo "Booting $DEVICE_ID"
           xcrun simctl boot "$DEVICE_ID" || true
 
-      - name: Run iOS runtime smoke
+      - name: Run iOS runtime check
         run: ./integration-tests/run.sh 57 --platform ios --architecture new --smoke
 
   # Single aggregate check that summarizes the whole matrix. Point branch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,8 @@
 name: Tests
 
-# Thin wrapper so all integration test checks display namespaced under a
-# single "tests /" group in the PR checks panel. The actual jobs live in
-# integration-tests.yml (also called by build.yml before stable publishes).
+# Thin wrapper so focused PR checks display namespaced under a single "tests /"
+# group. Manual runs default to the full compatibility matrix. The actual jobs
+# live in integration-tests.yml (also called before RC and stable publishes).
 
 on:
   pull_request:
@@ -11,13 +11,27 @@ on:
       - 'android/**'
       - 'ios/**'
       - 'src/**'
+      - '__tests__/**'
       - 'react-native.config.js'
       - '*.podspec'
       - 'package.json'
+      - 'package-lock.json'
+      - 'build.sh'
+      - '.eslintrc.js'
+      - 'babel.config.js'
+      - 'jest.config.js'
+      - 'tsconfig*.json'
       - 'integration-tests/**'
+      - '.github/workflows/build.yml'
       - '.github/workflows/integration-tests.yml'
       - '.github/workflows/tests.yml'
   workflow_dispatch:
+    inputs:
+      run-compatibility-matrix:
+        description: Run older SDK, legacy architecture, and static-framework build checks
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -30,3 +44,7 @@ concurrency:
 jobs:
   tests:
     uses: ./.github/workflows/integration-tests.yml
+    with:
+      # Pull requests use focused checks. A manual run can opt into or out of
+      # the full compatibility matrix and defaults to running it.
+      run-compatibility-matrix: ${{ github.event_name == 'workflow_dispatch' && inputs.run-compatibility-matrix }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ node_modules/
 # dotenv environment variables file
 .env
 .env.test
+.env*.local
 
 # Generated files
 lib/

--- a/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
+++ b/android/src/main/kotlin/com/appstack/reactnative/AppstackReactNativeModule.kt
@@ -57,7 +57,7 @@ class AppstackReactNativeModule(reactContext: ReactApplicationContext) :
             // Testing-only proxy override, read from the app's manifest metadata. This is
             // NOT exposed through the public configure() API: a proxy URL is applied only if
             // the host app deliberately ships an APPSTACK_DEV_PROXY_URL <meta-data> entry
-            // (this repo's homepage-app does; published-package consumers do not). Routed
+            // (this repo's demo/test hosts do; published-package consumers do not). Routed
             // through the SDK's internal setProxyUrl hook, before configure so the SDK's
             // initial requests target it.
             readDevProxyUrl()?.takeIf { it.isNotBlank() }?.let {

--- a/homepage-app/.env.example
+++ b/homepage-app/.env.example
@@ -1,0 +1,3 @@
+# Expo exposes EXPO_PUBLIC_* values to the application bundle. Keep real values
+# in an ignored .env.local file and never commit them.
+EXPO_PUBLIC_APPSTACK_API_KEY=replace-with-a-development-api-key

--- a/homepage-app/README.md
+++ b/homepage-app/README.md
@@ -5,7 +5,8 @@ This is a demo React Native app showcasing the Appstack Attribution SDK integrat
 ## Features
 
 This demo app demonstrates:
-- ✅ **Full SDK Configuration** - All available parameters including debug mode, custom endpoints, and log levels
+- ✅ **Environment-based Configuration** - Local API-key configuration and log levels without committed credentials
+- ✅ **Repository-only Dev Routing** - Native traffic from this demo is routed to Appstack's development endpoint
 - ✅ **Basic Configuration** - Backward-compatible simple setup
 - ✅ **Event Tracking** - Standard events, custom events, and revenue tracking
 - ✅ **Error Handling** - Comprehensive error handling and user feedback
@@ -19,7 +20,17 @@ This demo app demonstrates:
    npm install
    ```
 
-2. Start the app
+2. Create a local environment file and provide a development API key
+
+   ```bash
+   cp .env.example .env.local
+   ```
+
+   Edit `.env.local` and replace the placeholder. Expo embeds
+   `EXPO_PUBLIC_*` values in the application bundle, so do not treat this value
+   as a private secret or commit a real key.
+
+3. Start the app
 
    ```bash
    npx expo start
@@ -36,26 +47,36 @@ You can start developing by editing the files inside the **app** directory. This
 
 ## Appstack SDK Usage
 
-### Configuration Options
+### Configuration
 
-The SDK supports multiple configuration approaches:
+The demo reads its key from `EXPO_PUBLIC_APPSTACK_API_KEY` and refuses to
+initialize when it is missing:
 
-#### Full Configuration (Recommended for Development)
 ```typescript
 import AppstackSDK from 'react-native-appstack-sdk';
 
+const apiKey = process.env.EXPO_PUBLIC_APPSTACK_API_KEY?.trim();
+if (!apiKey) {
+  throw new Error('Missing EXPO_PUBLIC_APPSTACK_API_KEY');
+}
+
 await AppstackSDK.configure(
-  'your-api-key',
-  true, // isDebug - enable debug mode
-  'https://api.event.dev.appstack.tech/android/', // endpointBaseUrl - custom endpoint
+  apiKey,
+  false, // Deprecated compatibility argument; ignored
+  undefined, // Deprecated endpoint argument; ignored
   0 // logLevel - 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR
 );
 ```
 
-#### Basic Configuration (Production)
+The development endpoint is selected by the repository-only
+`withAppstackDevProxy` Expo config plugin. `configure()` does not expose or
+forward a custom endpoint, and applications consuming the published package do
+not receive this demo plugin.
+
+#### Basic Configuration
+
 ```typescript
-// Backward compatible - uses default values
-await AppstackSDK.configure('your-api-key');
+await AppstackSDK.configure(apiKey);
 ```
 
 #### Parameter Details
@@ -63,9 +84,10 @@ await AppstackSDK.configure('your-api-key');
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `apiKey` | `string` | **Required** | Your Appstack API key from the dashboard |
-| `isDebug` | `boolean` | `false` | Enable debug mode for detailed logging |
-| `endpointBaseUrl` | `string?` | Platform default | Custom API endpoint URL |
+| `isDebug` | `boolean` | `false` | Deprecated compatibility argument; accepted but ignored |
+| `endpointBaseUrl` | `string?` | `undefined` | Deprecated compatibility argument; accepted but not forwarded to native code |
 | `logLevel` | `number` | `1` (INFO) | Log level: 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR |
+| `customerUserId` | `string?` | `undefined` | Optional customer user identifier |
 
 ### Event Tracking
 
@@ -138,7 +160,7 @@ This app demonstrates all SDK capabilities:
 
 ## Development Tips
 
-1. **Use Debug Mode** - Enable `isDebug: true` during development for detailed logs
+1. **Use DEBUG Logging Deliberately** - Pass log level `0` during local development when detailed logs are needed
 2. **Test Both Platforms** - Verify functionality on both iOS and Android
 3. **Handle Errors** - Always wrap SDK calls in try-catch blocks
 4. **Validate Revenue** - Ensure revenue values are valid numbers

--- a/homepage-app/app/(tabs)/index.tsx
+++ b/homepage-app/app/(tabs)/index.tsx
@@ -30,12 +30,11 @@ export default function HomeScreen() {
       console.log('AppstackReactNative module:', NativeModules.AppstackReactNative);
       console.log('Is AppstackReactNative available:', !!NativeModules.AppstackReactNative);
 
-      // Read API key from environment
-      // const apiKey = process.env.EXPO_PUBLIC_APPSTACK_API_KEY;
-      //let apiKey = 'EXPO_PUBLIC_APPSTACK_API_KEY';
-      let apiKey = "q40jebdl91tgelzcrp5pbnbh"
+      // This demo reads its API key from local environment configuration. Never
+      // commit a real key to the sample application.
+      const apiKey = process.env.EXPO_PUBLIC_APPSTACK_API_KEY?.trim();
 
-      if (!apiKey || apiKey.trim() === '') {
+      if (!apiKey) {
         const msg = 'Missing EXPO_PUBLIC_APPSTACK_API_KEY. Set it in your env (e.g. eas.json env or .env) to initialize the SDK.';
         console.warn(msg);
         setSdkError(msg);
@@ -47,7 +46,7 @@ export default function HomeScreen() {
       // (ios/homepageapp/Info.plist + android/app/src/main/AndroidManifest.xml), not through
       // configure() — isDebug and endpointBaseUrl are deprecated no-ops in the wrapper.
       await AppstackSDK.configure(
-        apiKey.trim(),
+        apiKey,
         true, // isDebug - deprecated/ignored
         undefined, // endpointBaseUrl - deprecated/ignored (see APPSTACK_DEV_PROXY_URL)
         0 // logLevel - 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR
@@ -163,14 +162,18 @@ export default function HomeScreen() {
   const reinitializeWithBasicConfig = async () => {
     try {
       console.log('Reinitializing with basic configuration...');
-      
-      let apiKey = 'your-appstack-api-key';
-      if (Platform.OS === 'ios') {
-        apiKey = 'your-appstack-api-key';
+
+      const apiKey = process.env.EXPO_PUBLIC_APPSTACK_API_KEY?.trim();
+      if (!apiKey) {
+        const msg = 'Missing EXPO_PUBLIC_APPSTACK_API_KEY. Set it before configuring the SDK.';
+        setSdkError(msg);
+        setIsSDKInitialized(false);
+        Alert.alert('SDK configuration missing', msg);
+        return;
       }
 
       // Basic configuration (backward compatible)
-      await AppstackSDK.configure(apiKey.trim());
+      await AppstackSDK.configure(apiKey);
       
       setIsSDKInitialized(true);
       setSdkError(null);
@@ -218,7 +221,7 @@ export default function HomeScreen() {
       <ThemedView style={styles.stepContainer}>
         <ThemedText type="subtitle">Configuration Options</ThemedText>
         <ThemedText style={styles.infoText}>
-          Current: Full configuration with debug mode, custom endpoint, and DEBUG log level
+          Current: Environment-provided API key, repo-only dev routing, and DEBUG log level
         </ThemedText>
         <TouchableOpacity style={styles.secondaryButton} onPress={reinitializeWithBasicConfig}>
           <ThemedText style={styles.buttonText}>Test Basic Configuration</ThemedText>

--- a/homepage-app/plugins/withAppstackDevProxy.js
+++ b/homepage-app/plugins/withAppstackDevProxy.js
@@ -9,10 +9,10 @@ const {
 // the SDK bridge's internal setProxyUrl hook (see AppstackBridge.swift /
 // AppstackReactNativeModule.kt, which read APPSTACK_DEV_PROXY_URL).
 //
-// It is NOT part of the published react-native-appstack-sdk package: only the
-// homepage-app's app.json references this plugin, so integrators' apps never ship
-// the key and always hit production. This mirrors the Flutter sample_app's
-// Info.plist / AndroidManifest APPSTACK_DEV_PROXY_URL hook.
+// It is NOT part of the published react-native-appstack-sdk package. Only
+// repository-owned demo/test hosts use or copy this plugin, so consumer apps do
+// not ship the key. This mirrors the Flutter sample_app's Info.plist /
+// AndroidManifest APPSTACK_DEV_PROXY_URL hook.
 const KEY = 'APPSTACK_DEV_PROXY_URL';
 const IOS_DEV_PROXY = 'https://api.event.dev.appstack.tech';
 const ANDROID_DEV_PROXY = 'https://api.event.dev.appstack.tech/android/';

--- a/integration-tests/AndroidManifest.runtime.xml
+++ b/integration-tests/AndroidManifest.runtime.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+  <application
+      android:networkSecurityConfig="@xml/appstack_runtime_validation_network_security_config"
+      android:usesCleartextTraffic="true"
+      tools:replace="android:usesCleartextTraffic">
+    <meta-data
+        android:name="APPSTACK_DEV_PROXY_URL"
+        android:value="__APPSTACK_RUNTIME_PROXY_URL__" />
+  </application>
+</manifest>

--- a/integration-tests/mock_server.py
+++ b/integration-tests/mock_server.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Loopback-only recording backend for hermetic native SDK runtime checks."""
+
+import argparse
+import json
+import signal
+import ssl
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+
+MAX_REQUEST_BODY_BYTES = 1024 * 1024
+SENSITIVE_NAMES = {
+    "authorization",
+    "cookie",
+    "proxy-authorization",
+    "set-cookie",
+    "x-api-key",
+    "api-key",
+    "apikey",
+    "token",
+}
+
+
+def is_sensitive(name: str) -> bool:
+    normalized = name.lower().replace("_", "-")
+    return normalized in SENSITIVE_NAMES or normalized.endswith("-token")
+
+
+def redact_path(value: str) -> str:
+    parsed = urlsplit(value)
+    query = [
+        (key, "[REDACTED]" if is_sensitive(key) else item)
+        for key, item in parse_qsl(parsed.query, keep_blank_values=True)
+    ]
+    return urlunsplit(("", "", parsed.path, urlencode(query), parsed.fragment))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port-file", required=True)
+    parser.add_argument("--requests-file", required=True)
+    parser.add_argument("--tls-cert")
+    parser.add_argument("--tls-key")
+    parser.add_argument("--tls-port-file")
+    args = parser.parse_args()
+
+    tls_arguments = (args.tls_cert, args.tls_key, args.tls_port_file)
+    if any(tls_arguments) and not all(tls_arguments):
+        parser.error("--tls-cert, --tls-key, and --tls-port-file must be used together")
+
+    requests_path = Path(args.requests_file)
+    write_lock = threading.Lock()
+
+    class Handler(BaseHTTPRequestHandler):
+        server_version = "AppstackRuntimeRecorder/1"
+        sys_version = ""
+
+        def do_GET(self) -> None:
+            path = urlsplit(self.path).path
+            self.record(None)
+            if path.endswith("/config"):
+                if path.startswith("/ios/"):
+                    match_url = (
+                        f"http://127.0.0.1:{http_server.server_port}"
+                        "/attribution/match/runtime_validation_app"
+                    )
+                elif tls_server is not None:
+                    match_url = (
+                        f"https://127.0.0.1:{tls_server.server_port}"
+                        "/attribution/match"
+                    )
+                else:
+                    self.respond(500, {"error": "TLS match endpoint is not configured"})
+                    return
+                self.respond(
+                    200,
+                    {
+                        "app_id": "runtime_validation_app",
+                        "sdk_enabled": True,
+                        "match_url": match_url,
+                        "use_install_detection_v2": False,
+                    },
+                )
+                return
+            if "/attribution/match" in path:
+                self.respond(
+                    200,
+                    {
+                        "deeplink_id": "runtime-validation-deeplink",
+                        "app_id": "runtime_validation_app",
+                        "redirection_url": "https://example.invalid/app",
+                        "timestamp": "2026-07-13T00:00:00Z",
+                        "method": "GET",
+                        "url": "https://example.invalid/deeplink",
+                        "query_params": {
+                            "runtime_validation": "attributed",
+                            "unicode": "café 🚀",
+                            "source": "local-recorder",
+                        },
+                        "path_params": {},
+                        "cookies": {},
+                        "install_id": "runtime-validation-install",
+                        "event_type": "install",
+                        "date_day": "2026-07-13",
+                    },
+                )
+                return
+            self.respond(404, {"error": "unknown path"})
+
+        def do_POST(self) -> None:
+            body = self.read_json_body()
+            if body is _BODY_TOO_LARGE:
+                return
+            self.record(body)
+            path = urlsplit(self.path).path
+            if path.endswith("/events"):
+                self.respond(200, {"status": "success", "message": "ok"})
+                return
+            if path == "/runtime-result":
+                self.respond(200, {"status": "recorded"})
+                return
+            self.respond(404, {"error": "unknown path"})
+
+        def read_json_body(self):
+            raw_length = self.headers.get("Content-Length", "0")
+            try:
+                length = int(raw_length)
+            except ValueError:
+                self.respond(400, {"error": "invalid content length"})
+                return _BODY_TOO_LARGE
+            if length < 0 or length > MAX_REQUEST_BODY_BYTES:
+                self.respond(413, {"error": "request body too large"})
+                return _BODY_TOO_LARGE
+            raw = self.rfile.read(length) if length else b""
+            if not raw:
+                return None
+            try:
+                return json.loads(raw.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                return {"_invalid_json": True}
+
+        def record(self, body) -> None:
+            entry = {
+                "method": self.command,
+                "path": redact_path(self.path),
+                "headers": {
+                    key.lower(): "[REDACTED]" if is_sensitive(key) else value
+                    for key, value in self.headers.items()
+                },
+                "body": body,
+            }
+            with write_lock:
+                with requests_path.open("a", encoding="utf-8") as stream:
+                    stream.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                    stream.flush()
+
+        def respond(self, status: int, value) -> None:
+            payload = json.dumps(value, ensure_ascii=False).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, _format: str, *_args) -> None:
+            return
+
+    http_server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    tls_server = None
+    tls_thread = None
+    if all(tls_arguments):
+        tls_server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        tls_context.load_cert_chain(args.tls_cert, args.tls_key)
+        tls_server.socket = tls_context.wrap_socket(tls_server.socket, server_side=True)
+        Path(args.tls_port_file).write_text(
+            str(tls_server.server_port), encoding="utf-8"
+        )
+        tls_thread = threading.Thread(target=tls_server.serve_forever, daemon=True)
+        tls_thread.start()
+
+    Path(args.port_file).write_text(str(http_server.server_port), encoding="utf-8")
+
+    def stop(_signum, _frame) -> None:
+        threading.Thread(target=http_server.shutdown, daemon=True).start()
+        if tls_server is not None:
+            threading.Thread(target=tls_server.shutdown, daemon=True).start()
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    http_server.serve_forever()
+    http_server.server_close()
+    if tls_server is not None:
+        tls_server.shutdown()
+        tls_server.server_close()
+    if tls_thread is not None:
+        tls_thread.join(timeout=1)
+
+
+_BODY_TOO_LARGE = object()
+
+
+if __name__ == "__main__":
+    main()

--- a/integration-tests/mock_server.py
+++ b/integration-tests/mock_server.py
@@ -2,11 +2,10 @@
 """Loopback-only recording backend for hermetic native SDK runtime checks."""
 
 import argparse
-import faulthandler
 import json
 import signal
+import socketserver
 import ssl
-import sys
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -24,6 +23,16 @@ SENSITIVE_NAMES = {
     "apikey",
     "token",
 }
+
+
+class LoopbackThreadingHTTPServer(ThreadingHTTPServer):
+    """HTTP server that does not depend on reverse DNS during loopback binding."""
+
+    def server_bind(self) -> None:
+        socketserver.TCPServer.server_bind(self)
+        host, port = self.server_address[:2]
+        self.server_name = host
+        self.server_port = port
 
 
 def is_sensitive(name: str) -> bool:
@@ -170,21 +179,11 @@ def main() -> None:
         def log_message(self, _format: str, *_args) -> None:
             return
 
-    print("constructing loopback HTTP server", file=sys.stderr, flush=True)
-    faulthandler.dump_traceback_later(5, repeat=False, file=sys.stderr)
-    try:
-        http_server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-    finally:
-        faulthandler.cancel_dump_traceback_later()
-    print(
-        f"loopback HTTP server bound to port {http_server.server_port}",
-        file=sys.stderr,
-        flush=True,
-    )
+    http_server = LoopbackThreadingHTTPServer(("127.0.0.1", 0), Handler)
     tls_server = None
     tls_thread = None
     if all(tls_arguments):
-        tls_server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        tls_server = LoopbackThreadingHTTPServer(("127.0.0.1", 0), Handler)
         tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         tls_context.load_cert_chain(args.tls_cert, args.tls_key)
         tls_server.socket = tls_context.wrap_socket(tls_server.socket, server_side=True)

--- a/integration-tests/mock_server.py
+++ b/integration-tests/mock_server.py
@@ -2,9 +2,11 @@
 """Loopback-only recording backend for hermetic native SDK runtime checks."""
 
 import argparse
+import faulthandler
 import json
 import signal
 import ssl
+import sys
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -168,7 +170,17 @@ def main() -> None:
         def log_message(self, _format: str, *_args) -> None:
             return
 
-    http_server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    print("constructing loopback HTTP server", file=sys.stderr, flush=True)
+    faulthandler.dump_traceback_later(5, repeat=False, file=sys.stderr)
+    try:
+        http_server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    finally:
+        faulthandler.cancel_dump_traceback_later()
+    print(
+        f"loopback HTTP server bound to port {http_server.server_port}",
+        file=sys.stderr,
+        flush=True,
+    )
     tls_server = None
     tls_thread = None
     if all(tls_arguments):

--- a/integration-tests/network_security_config.xml
+++ b/integration-tests/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <base-config cleartextTrafficPermitted="true">
+    <trust-anchors>
+      <certificates src="system" />
+      <certificates src="@raw/appstack_runtime_validation_ca" />
+    </trust-anchors>
+  </base-config>
+</network-security-config>

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -291,18 +291,30 @@ npm install --no-audit --no-fund "$TARBALL"
 if [[ "$STATIC_FRAMEWORKS" == true ]]; then
   npm install --no-audit --no-fund expo-build-properties
 fi
-STATIC_FRAMEWORKS="$STATIC_FRAMEWORKS" node -e "
+if [[ "$SMOKE_MODE" == true ]]; then
+  # Interim safety guard until the hermetic loopback recorder is introduced:
+  # repository smoke hosts must explicitly carry the repo-only native proxy
+  # configuration so a fake-key run cannot fall back to production endpoints.
+  cp "$ROOT_DIR/homepage-app/plugins/withAppstackDevProxy.js" \
+    "$APP_DIR/withAppstackDevProxy.js"
+fi
+STATIC_FRAMEWORKS="$STATIC_FRAMEWORKS" SMOKE_MODE="$SMOKE_MODE" node -e "
   const fs = require('fs');
   const j = JSON.parse(fs.readFileSync('app.json', 'utf8'));
   j.expo.android = { ...(j.expo.android || {}), package: 'com.appstack.e2e' };
   j.expo.ios = { ...(j.expo.ios || {}), bundleIdentifier: 'com.appstack.e2e' };
-  // Normalize the expo-build-properties plugin so reused app dirs don't leak
-  // a previous run's framework setting.
+  // Normalize repo-owned plugins so reused app dirs do not leak settings from
+  // a previous run.
   const plugins = (j.expo.plugins || []).filter(
-    (p) => (Array.isArray(p) ? p[0] : p) !== 'expo-build-properties'
+    (p) => !['expo-build-properties', './withAppstackDevProxy'].includes(
+      Array.isArray(p) ? p[0] : p
+    )
   );
   if (process.env.STATIC_FRAMEWORKS === 'true') {
     plugins.push(['expo-build-properties', { ios: { useFrameworks: 'static' } }]);
+  }
+  if (process.env.SMOKE_MODE === 'true') {
+    plugins.push('./withAppstackDevProxy');
   }
   j.expo.plugins = plugins;
   fs.writeFileSync('app.json', JSON.stringify(j, null, 2));

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -9,8 +9,11 @@ set -euo pipefail
 # podspec header path issues) before they hit consumers.
 #
 # Usage: ./integration-tests/run.sh <expo-sdk-version> [options]
-#   <expo-sdk-version>    Expo SDK major version, e.g. 54, 55, 56
+#   <expo-sdk-version>    Expo SDK major version, e.g. 54, 55, 56, 57
 #   --platform <p>        android (default) or ios
+#   --architecture <a>    new (default) or legacy. SDK 54 writes this explicitly
+#                         to Expo config; SDK 55+ supports only new architecture.
+#                         The generated native configuration is always checked.
 #   --quick               Stop after the autolinking assertion (no full native
 #                         build). Useful for fast local iteration.
 #   --static-frameworks   iOS only: build with `useFrameworks: "static"` via
@@ -25,23 +28,47 @@ set -euo pipefail
 #                         reactivecircus/android-emulator-runner), iOS via a
 #                         booted simulator (in CI: xcrun simctl boot).
 
-SDK_VERSION="${1:?Usage: $0 <expo-sdk-version> [--platform android|ios] [--quick] [--static-frameworks]}"
+SDK_VERSION="${1:?Usage: $0 <expo-sdk-version> [--platform android|ios] [--architecture new|legacy] [--quick] [--static-frameworks] [--smoke]}"
 shift
 
 PLATFORM="android"
+ARCHITECTURE="new"
 QUICK_MODE=false
 STATIC_FRAMEWORKS=false
 SMOKE_MODE=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --platform) PLATFORM="${2:?--platform requires a value}"; shift 2 ;;
+    --architecture) ARCHITECTURE="${2:?--architecture requires a value}"; shift 2 ;;
     --quick) QUICK_MODE=true; shift ;;
     --static-frameworks) STATIC_FRAMEWORKS=true; shift ;;
     --smoke) SMOKE_MODE=true; shift ;;
     *) echo "Unknown option: $1" >&2; exit 2 ;;
   esac
 done
+[[ "$SDK_VERSION" =~ ^[0-9]+$ ]] || { echo "Invalid Expo SDK version: $SDK_VERSION (expected a major version)" >&2; exit 2; }
+SDK_MAJOR=$((10#$SDK_VERSION))
 [[ "$PLATFORM" == "android" || "$PLATFORM" == "ios" ]] || { echo "Invalid platform: $PLATFORM" >&2; exit 2; }
+[[ "$ARCHITECTURE" == "new" || "$ARCHITECTURE" == "legacy" ]] || {
+  echo "Invalid architecture: $ARCHITECTURE (expected new or legacy)" >&2
+  exit 2
+}
+if (( SDK_MAJOR >= 55 )) && [[ "$ARCHITECTURE" == "legacy" ]]; then
+  echo "Expo SDK ${SDK_VERSION} does not support the legacy architecture; use Expo SDK 54 or earlier" >&2
+  exit 2
+fi
+if [[ "$ARCHITECTURE" == "new" ]]; then
+  NEW_ARCH_ENABLED=true
+else
+  NEW_ARCH_ENABLED=false
+fi
+if (( SDK_MAJOR <= 54 )); then
+  WRITE_NEW_ARCH_CONFIG=true
+else
+  # Expo removed newArchEnabled from its documented app-config schema in SDK 55.
+  # New Architecture is mandatory there, so let Expo generate its native defaults.
+  WRITE_NEW_ARCH_CONFIG=false
+fi
 if [[ "$SMOKE_MODE" == true && "$QUICK_MODE" == true ]]; then
   echo "--smoke cannot be combined with --quick (smoke needs a full runnable build)" >&2; exit 2
 fi
@@ -259,7 +286,7 @@ run_ios_smoke() {
   fail "Timed out waiting for SDK smoke sentinel (no round-trip confirmation)"
 }
 
-log "Expo SDK ${SDK_VERSION} / ${PLATFORM} integration test (workdir: ${WORK_DIR})"
+log "Expo SDK ${SDK_VERSION} / ${PLATFORM} / ${ARCHITECTURE} architecture integration test (workdir: ${WORK_DIR})"
 
 # 1. Pack the SDK (prepack hook builds lib/ via bob)
 cd "$ROOT_DIR"
@@ -298,9 +325,17 @@ if [[ "$SMOKE_MODE" == true ]]; then
   cp "$ROOT_DIR/homepage-app/plugins/withAppstackDevProxy.js" \
     "$APP_DIR/withAppstackDevProxy.js"
 fi
-STATIC_FRAMEWORKS="$STATIC_FRAMEWORKS" SMOKE_MODE="$SMOKE_MODE" node -e "
+STATIC_FRAMEWORKS="$STATIC_FRAMEWORKS" SMOKE_MODE="$SMOKE_MODE" \
+  NEW_ARCH_ENABLED="$NEW_ARCH_ENABLED" WRITE_NEW_ARCH_CONFIG="$WRITE_NEW_ARCH_CONFIG" node -e "
   const fs = require('fs');
   const j = JSON.parse(fs.readFileSync('app.json', 'utf8'));
+  if (process.env.WRITE_NEW_ARCH_CONFIG === 'true') {
+    j.expo.newArchEnabled = process.env.NEW_ARCH_ENABLED === 'true';
+  } else {
+    // SDK 55+ always uses New Architecture and no longer documents this field.
+    // Delete stale values when reusing a generated test app between runs.
+    delete j.expo.newArchEnabled;
+  }
   j.expo.android = { ...(j.expo.android || {}), package: 'com.appstack.e2e' };
   j.expo.ios = { ...(j.expo.ios || {}), bundleIdentifier: 'com.appstack.e2e' };
   // Normalize repo-owned plugins so reused app dirs do not leak settings from
@@ -326,6 +361,17 @@ rm -rf "$PLATFORM"
 CI=1 npx expo prebuild --platform "$PLATFORM" --no-install
 
 if [[ "$PLATFORM" == "android" ]]; then
+  ACTUAL_NEW_ARCH="$(sed -n 's/^newArchEnabled=//p' android/gradle.properties | tail -1)"
+  if (( SDK_MAJOR >= 55 )); then
+    [[ -z "$ACTUAL_NEW_ARCH" || "$ACTUAL_NEW_ARCH" == "true" ]] \
+      || fail "Android generated an invalid mandatory-architecture setting: newArchEnabled=${ACTUAL_NEW_ARCH}"
+    log "Android architecture confirmed: new architecture is mandatory in Expo SDK ${SDK_VERSION} (newArchEnabled=${ACTUAL_NEW_ARCH:-<omitted>})"
+  else
+    [[ "$ACTUAL_NEW_ARCH" == "$NEW_ARCH_ENABLED" ]] \
+      || fail "Android architecture mismatch: requested ${ARCHITECTURE}, generated newArchEnabled=${ACTUAL_NEW_ARCH:-<missing>}"
+    log "Android architecture confirmed: ${ARCHITECTURE} (newArchEnabled=${ACTUAL_NEW_ARCH})"
+  fi
+
   # 5a. Generate PackageList.java and assert our package is linked correctly
   cd android
   log "Generating autolinking PackageList..."
@@ -364,6 +410,20 @@ if [[ "$PLATFORM" == "android" ]]; then
     ./gradlew --no-daemon :app:assembleDebug
   fi
 else
+  ACTUAL_NEW_ARCH="$(node -e '
+    const p = require("./ios/Podfile.properties.json");
+    if (p.newArchEnabled !== undefined) process.stdout.write(String(p.newArchEnabled));
+  ')"
+  if (( SDK_MAJOR >= 55 )); then
+    [[ -z "$ACTUAL_NEW_ARCH" || "$ACTUAL_NEW_ARCH" == "true" ]] \
+      || fail "iOS generated an invalid mandatory-architecture setting: newArchEnabled=${ACTUAL_NEW_ARCH}"
+    log "iOS architecture confirmed: new architecture is mandatory in Expo SDK ${SDK_VERSION} (newArchEnabled=${ACTUAL_NEW_ARCH:-<omitted>})"
+  else
+    [[ "$ACTUAL_NEW_ARCH" == "$NEW_ARCH_ENABLED" ]] \
+      || fail "iOS architecture mismatch: requested ${ARCHITECTURE}, generated newArchEnabled=${ACTUAL_NEW_ARCH:-<missing>}"
+    log "iOS architecture confirmed: ${ARCHITECTURE} (newArchEnabled=${ACTUAL_NEW_ARCH})"
+  fi
+
   # 5b. Install pods and assert the SDK pod was autolinked
   cd ios
   log "Installing pods..."
@@ -416,4 +476,4 @@ else
   fi
 fi
 
-log "✅ Expo SDK ${SDK_VERSION} / ${PLATFORM} integration test passed"
+log "✅ Expo SDK ${SDK_VERSION} / ${PLATFORM} / ${ARCHITECTURE} architecture integration test passed"

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -Eeuo pipefail
 
 # Integration test: verify the SDK autolinks and compiles in a fresh Expo app.
 #
@@ -19,14 +19,11 @@ set -euo pipefail
 #   --static-frameworks   iOS only: build with `useFrameworks: "static"` via
 #                         expo-build-properties (exercises different header
 #                         search paths, common in apps using Firebase etc.)
-#   --smoke               After building, install the app on a running emulator
-#                         (Android) or simulator (iOS), launch it, and assert the
-#                         JS -> bridge -> native SDK round trip actually works at
-#                         runtime (catches bridge-registration / crash-on-init
-#                         bugs that a compile-only build cannot). Requires a
-#                         device to be available: Android via adb (in CI:
-#                         reactivecircus/android-emulator-runner), iOS via a
-#                         booted simulator (in CI: xcrun simctl boot).
+#   --smoke               Run a hermetic runtime check against a loopback-only
+#                         recording backend. Builds and launches a self-contained
+#                         app, exercises the public JS API through the real native
+#                         SDK, and validates native HTTP requests. Requires an
+#                         Android emulator/device or iOS simulator.
 
 SDK_VERSION="${1:?Usage: $0 <expo-sdk-version> [--platform android|ios] [--architecture new|legacy] [--quick] [--static-frameworks] [--smoke]}"
 shift
@@ -81,15 +78,105 @@ APP_DIR="${WORK_DIR}/${APP_NAME}"
 log()  { echo "▶ $*"; }
 fail() { echo "❌ $*" >&2; exit 1; }
 
-# Values the smoke entrypoint passes to configure(). The bridge no longer logs
-# its arguments (device logging is delegated to the native SDK's sanitized,
-# level-gated logger), so these are not asserted against logs; the configure ->
-# sendEvent -> getAppstackId round trip — and the UUID getAppstackId returns — is
-# what proves the arguments marshaled across the boundary. Kept distinctive so
-# they stand out in captured log dumps when a run fails.
-SMOKE_API_KEY="SMOKEKEY-abc12345"
-SMOKE_LOG_LEVEL="2"
-SMOKE_USER_ID="smoke-user-42"
+RUNTIME_DIR=""
+RUNTIME_LOG=""
+REQUESTS_FILE=""
+MOCK_LOG=""
+MOCK_PID=""
+RUNTIME_LOG_PID=""
+RUNTIME_HTTP_PORT=""
+RUNTIME_TLS_PORT=""
+RUNTIME_TLS_CERT=""
+ANDROID_ADB=""
+ANDROID_INSTALLED_PACKAGE=""
+ANDROID_REVERSED_HTTP=""
+ANDROID_REVERSED_TLS=""
+IOS_RUNTIME_UDID=""
+IOS_INSTALLED_BUNDLE=""
+
+print_runtime_diagnostics() {
+  [[ -n "$RUNTIME_DIR" ]] || return 0
+  echo "---- bounded runtime diagnostics ----" >&2
+  if [[ -s "$RUNTIME_LOG" ]]; then
+    grep -iE 'APPSTACK_RUNTIME|Appstack|FATAL EXCEPTION|AndroidRuntime' \
+      "$RUNTIME_LOG" 2>/dev/null \
+      | tail -60 \
+      | sed 's/^/    | /' >&2 || true
+  fi
+  if [[ -s "$MOCK_LOG" ]]; then
+    echo "    mock server:" >&2
+    tail -30 "$MOCK_LOG" | sed 's/^/    | /' >&2
+  fi
+  if [[ -s "$REQUESTS_FILE" ]]; then
+    echo "    recorder captured $(wc -l < "$REQUESTS_FILE" | tr -d ' ') request(s)" >&2
+    python3 - "$REQUESTS_FILE" <<'PY' \
+      | tail -30 \
+      | sed 's/^/    | /' >&2 || true
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8", errors="replace") as stream:
+    for line in stream:
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            print("invalid recorder entry")
+            continue
+        body = item.get("body") if isinstance(item.get("body"), dict) else {}
+        event = body.get("event_name")
+        suffix = f" event={event}" if event else ""
+        print(f"{item.get('method', '?')} {item.get('path', '?')}{suffix}")
+PY
+  else
+    echo "    recorder captured no requests" >&2
+  fi
+}
+
+cleanup_runtime() {
+  local status=$?
+  set +e
+
+  if [[ -n "$RUNTIME_LOG_PID" ]]; then
+    kill "$RUNTIME_LOG_PID" 2>/dev/null
+    wait "$RUNTIME_LOG_PID" 2>/dev/null
+  fi
+  if [[ -n "$ANDROID_ADB" && -n "$ANDROID_INSTALLED_PACKAGE" ]]; then
+    "$ANDROID_ADB" shell am force-stop "$ANDROID_INSTALLED_PACKAGE" >/dev/null 2>&1
+    "$ANDROID_ADB" uninstall "$ANDROID_INSTALLED_PACKAGE" >/dev/null 2>&1
+  fi
+  if [[ -n "$ANDROID_ADB" && -n "$ANDROID_REVERSED_HTTP" ]]; then
+    "$ANDROID_ADB" reverse --remove "tcp:$ANDROID_REVERSED_HTTP" >/dev/null 2>&1
+  fi
+  if [[ -n "$ANDROID_ADB" && -n "$ANDROID_REVERSED_TLS" ]]; then
+    "$ANDROID_ADB" reverse --remove "tcp:$ANDROID_REVERSED_TLS" >/dev/null 2>&1
+  fi
+  if [[ -n "$IOS_RUNTIME_UDID" && -n "$IOS_INSTALLED_BUNDLE" ]]; then
+    xcrun simctl terminate "$IOS_RUNTIME_UDID" "$IOS_INSTALLED_BUNDLE" >/dev/null 2>&1
+    xcrun simctl uninstall "$IOS_RUNTIME_UDID" "$IOS_INSTALLED_BUNDLE" >/dev/null 2>&1
+  fi
+  if [[ -n "$MOCK_PID" ]]; then
+    kill "$MOCK_PID" 2>/dev/null
+    wait "$MOCK_PID" 2>/dev/null
+  fi
+
+  if (( status != 0 )); then
+    print_runtime_diagnostics
+  fi
+
+  # The certificate is copied only into this generated debug source set. Remove
+  # it even when INTEGRATION_WORK_DIR keeps the rest of the fixture for reuse.
+  if [[ -n "$APP_DIR" ]]; then
+    rm -f -- \
+      "$APP_DIR/android/app/src/debug/res/raw/appstack_runtime_validation_ca.pem" \
+      "$APP_DIR/android/app/src/debug/res/xml/appstack_runtime_validation_network_security_config.xml"
+  fi
+  if [[ -n "$RUNTIME_DIR" && -d "$RUNTIME_DIR" \
+      && "$(basename "$RUNTIME_DIR")" == appstack-runtime.* ]]; then
+    rm -rf -- "$RUNTIME_DIR"
+  fi
+  return "$status"
+}
+trap cleanup_runtime EXIT
 
 # Resolve adb: prefer PATH, fall back to ANDROID_HOME/ANDROID_SDK_ROOT.
 adb_bin() {
@@ -100,47 +187,248 @@ adb_bin() {
   fail "adb not found (set ANDROID_HOME or put platform-tools on PATH)"
 }
 
-# Write a throwaway root component that drives configure -> sendEvent ->
-# getAppstackId on launch and prints a sentinel. The blank template's index
-# imports ./App, so overwriting App.js is enough regardless of the `main` field.
-# The distinctive SMOKE_* values are injected from the shell so the run_*_smoke
-# assertions can confirm they arrive intact on the native side.
-write_smoke_entrypoint() {
-  local app_dir="$1"
-  {
-    cat <<'JS_HEAD'
-import React, { useEffect, useState } from 'react';
-import { Text, View } from 'react-native';
-import AppstackSDK, { EventType } from 'react-native-appstack-sdk';
-JS_HEAD
-    printf '\n// Values injected by run.sh --smoke and passed straight into configure().\n'
-    printf '// Not asserted against logs anymore; the round trip below is the check.\n'
-    printf "const SMOKE_API_KEY = '%s';\n" "$SMOKE_API_KEY"
-    printf 'const SMOKE_LOG_LEVEL = %s;\n' "$SMOKE_LOG_LEVEL"
-    printf "const SMOKE_USER_ID = '%s';\n" "$SMOKE_USER_ID"
-    cat <<'JS_BODY'
+stop_runtime_log_capture() {
+  if [[ -n "$RUNTIME_LOG_PID" ]]; then
+    kill "$RUNTIME_LOG_PID" 2>/dev/null || true
+    wait "$RUNTIME_LOG_PID" 2>/dev/null || true
+    RUNTIME_LOG_PID=""
+  fi
+}
 
-// Smoke entrypoint injected by integration-tests/run.sh --smoke.
-// Exercises the JS -> bridge -> native round trip and logs a sentinel CI greps
-// for. A fake API key is fine: we assert the round trip resolves and
-// getAppstackId returns a real UUID, not that the backend accepts the key.
+start_runtime_backend() {
+  RUNTIME_DIR="$(mktemp -d "${WORK_DIR%/}/appstack-runtime.${PLATFORM}.XXXXXX")"
+  RUNTIME_LOG="$RUNTIME_DIR/runtime.log"
+  REQUESTS_FILE="$RUNTIME_DIR/requests.jsonl"
+  MOCK_LOG="$RUNTIME_DIR/mock-server.log"
+  local port_file="$RUNTIME_DIR/http-port"
+  local tls_port_file="$RUNTIME_DIR/tls-port"
+  local tls_key="$RUNTIME_DIR/localhost-key.pem"
+  RUNTIME_TLS_CERT="$RUNTIME_DIR/localhost-ca.pem"
+  : > "$RUNTIME_LOG"
+
+  local mock_arguments=(
+    --port-file "$port_file"
+    --requests-file "$REQUESTS_FILE"
+  )
+  if [[ "$PLATFORM" == "android" ]]; then
+    (
+      umask 077
+      openssl req -x509 -newkey rsa:2048 -sha256 -nodes -days 1 \
+        -subj '/CN=127.0.0.1' \
+        -addext 'subjectAltName=IP:127.0.0.1' \
+        -keyout "$tls_key" \
+        -out "$RUNTIME_TLS_CERT" \
+        >/dev/null 2>&1
+    )
+    mock_arguments+=(
+      --tls-cert "$RUNTIME_TLS_CERT"
+      --tls-key "$tls_key"
+      --tls-port-file "$tls_port_file"
+    )
+  fi
+
+  python3 "$ROOT_DIR/integration-tests/mock_server.py" "${mock_arguments[@]}" \
+    > "$MOCK_LOG" 2>&1 &
+  MOCK_PID=$!
+
+  for _ in $(seq 1 100); do
+    if [[ -s "$port_file" \
+        && ( "$PLATFORM" == "ios" || -s "$tls_port_file" ) ]]; then
+      break
+    fi
+    if ! kill -0 "$MOCK_PID" 2>/dev/null; then
+      fail "Runtime recording backend exited during startup"
+    fi
+    sleep 0.1
+  done
+  [[ -s "$port_file" ]] || fail "Runtime recording backend did not publish its HTTP port"
+  RUNTIME_HTTP_PORT="$(<"$port_file")"
+  [[ "$RUNTIME_HTTP_PORT" =~ ^[0-9]+$ ]] \
+    && (( RUNTIME_HTTP_PORT > 0 && RUNTIME_HTTP_PORT <= 65535 )) \
+    || fail "Runtime recording backend published an invalid HTTP port"
+
+  if [[ "$PLATFORM" == "android" ]]; then
+    [[ -s "$tls_port_file" ]] || fail "Runtime recording backend did not publish its TLS port"
+    RUNTIME_TLS_PORT="$(<"$tls_port_file")"
+    [[ "$RUNTIME_TLS_PORT" =~ ^[0-9]+$ ]] \
+      && (( RUNTIME_TLS_PORT > 0 && RUNTIME_TLS_PORT <= 65535 )) \
+      || fail "Runtime recording backend published an invalid TLS port"
+  fi
+
+  export APPSTACK_RUNTIME_PROXY_URL="http://127.0.0.1:${RUNTIME_HTTP_PORT}"
+  log "Loopback recording backend ready at ${APPSTACK_RUNTIME_PROXY_URL}"
+}
+
+configure_android_runtime_host() {
+  local android_root="$1"
+  local debug_root="$android_root/app/src/debug"
+  local raw_root="$debug_root/res/raw"
+  local xml_root="$debug_root/res/xml"
+  local manifest_template="$ROOT_DIR/integration-tests/AndroidManifest.runtime.xml"
+  local network_template="$ROOT_DIR/integration-tests/network_security_config.xml"
+  local build_gradle="$android_root/app/build.gradle"
+
+  [[ -f "$RUNTIME_TLS_CERT" ]] || fail "Runtime TLS certificate is missing"
+  [[ -f "$manifest_template" ]] || fail "Runtime Android manifest template is missing"
+  [[ -f "$network_template" ]] || fail "Runtime network-security template is missing"
+  [[ -f "$build_gradle" ]] || fail "Generated Android app/build.gradle is missing"
+
+  mkdir -p "$raw_root" "$xml_root"
+  cp "$RUNTIME_TLS_CERT" "$raw_root/appstack_runtime_validation_ca.pem"
+  cp "$network_template" \
+    "$xml_root/appstack_runtime_validation_network_security_config.xml"
+  sed "s|__APPSTACK_RUNTIME_PROXY_URL__|$APPSTACK_RUNTIME_PROXY_URL|g" \
+    "$manifest_template" > "$debug_root/AndroidManifest.xml"
+
+  APPSTACK_ANDROID_BUILD_GRADLE="$build_gradle" node -e '
+    const fs = require("fs");
+    const path = process.env.APPSTACK_ANDROID_BUILD_GRADLE;
+    const marker = "// Appstack runtime check: bundle JS into the debug APK.";
+    const source = fs.readFileSync(path, "utf8");
+    if (!source.includes("react {")) {
+      throw new Error("generated app/build.gradle has no React configuration block");
+    }
+    if (!source.includes(marker)) {
+      fs.writeFileSync(
+        path,
+        source.replace(
+          "react {",
+          `react {\n    ${marker}\n    debuggableVariants = []`
+        )
+      );
+    }
+  '
+}
+
+# Write a throwaway root component that exercises the public JS API and reports
+# one machine-readable terminal result to the loopback recorder. Console output
+# remains useful diagnostics, but Release builds need not expose it to simctl.
+write_runtime_entrypoint() {
+  local app_dir="$1"
+  cat > "${app_dir}/App.js" <<'JS'
+import React, { useEffect, useState } from 'react';
+import { Platform, Text, View } from 'react-native';
+import AppstackSDK, { EventType } from 'react-native-appstack-sdk';
+
+const RESULT_PREFIX = 'APPSTACK_RUNTIME_RESULT:';
+const FAILURE_PREFIX = 'APPSTACK_RUNTIME_FAIL:';
+const RESULT_URL = '__APPSTACK_RUNTIME_RESULT_URL__';
+const delay = (milliseconds) => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+async function reportResult(kind, payload) {
+  const response = await fetch(RESULT_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ kind, payload }),
+  });
+  if (!response.ok) {
+    throw new Error(`runtime recorder rejected result with HTTP ${response.status}`);
+  }
+}
+
+async function waitForAttribution() {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const value = await AppstackSDK.getAttributionParams();
+    if (
+      value &&
+      value.runtime_validation === 'attributed' &&
+      value.unicode === 'café 🚀'
+    ) {
+      return value;
+    }
+    await delay(500);
+  }
+  throw new Error('attribution parameters did not arrive from the recording backend');
+}
+
 export default function App() {
-  const [status, setStatus] = useState('APPSTACK_SMOKE_RUNNING');
+  const [status, setStatus] = useState('APPSTACK_RUNTIME_RUNNING');
   useEffect(() => {
     (async () => {
       try {
-        await AppstackSDK.configure(SMOKE_API_KEY, false, undefined, SMOKE_LOG_LEVEL, SMOKE_USER_ID);
-        await AppstackSDK.sendEvent(EventType.CUSTOM, 'APPSTACK_SMOKE_EVENT');
-        const id = await AppstackSDK.getAppstackId();
-        const uuidRe = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-        if (!id || !uuidRe.test(String(id))) {
-          throw new Error('getAppstackId returned a non-UUID value: ' + String(id));
+        const configured = await AppstackSDK.configure(
+          'runtime-validation-local-key',
+          false,
+          undefined,
+          0,
+          'runtime-validation-user'
+        );
+        const attribution = await waitForAttribution();
+        const callbackResults = await Promise.all([
+          AppstackSDK.getAttributionParams(),
+          AppstackSDK.getAttributionParams(),
+          AppstackSDK.getAttributionParams(),
+        ]);
+        const validCallbacks = callbackResults.filter(
+          value =>
+            value &&
+            value.runtime_validation === 'attributed' &&
+            value.unicode === 'café 🚀'
+        ).length;
+
+        const customAccepted = await AppstackSDK.sendEvent(
+          EventType.CUSTOM,
+          'runtime_validation_custom',
+          {
+            string: 'bridge-value',
+            number: 42,
+            decimal: 9.75,
+            boolean: true,
+            unicode: 'café 🚀',
+            array: ['one', 2, false],
+            nested: { enabled: true, items: ['nested', 3, false] },
+          }
+        );
+        const standardAccepted = await AppstackSDK.sendEvent(
+          EventType.LOGIN,
+          undefined,
+          { state: 'ready', sequence: 2 }
+        );
+
+        let validationError = '';
+        try {
+          await AppstackSDK.sendEvent();
+        } catch (error) {
+          validationError =
+            error && error.message ? error.message : String(error);
         }
-        console.log('APPSTACK_SMOKE_OK id=' + String(id));
-        setStatus('APPSTACK_SMOKE_OK');
-      } catch (e) {
-        console.error('APPSTACK_SMOKE_FAIL ' + (e && e.message ? e.message : String(e)));
-        setStatus('APPSTACK_SMOKE_FAIL');
+
+        // Native event delivery is fire-and-forget.
+        await delay(4000);
+        const appstackId = await AppstackSDK.getAppstackId();
+        const sdkDisabled = await AppstackSDK.isSdkDisabled();
+        const uuidRe = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+        const result = {
+          platform: Platform.OS,
+          configured: configured === true,
+          appstackIdPresent: uuidRe.test(String(appstackId || '')),
+          sdkDisabled,
+          callbackCount: callbackResults.length,
+          successCount: validCallbacks,
+          attributionValidated:
+            attribution.runtime_validation === 'attributed' &&
+            attribution.unicode === 'café 🚀',
+          eventsAccepted:
+            Number(customAccepted === true) + Number(standardAccepted === true),
+          validationError,
+          errors: [],
+        };
+        await reportResult('success', result);
+        console.log(RESULT_PREFIX + JSON.stringify(result));
+        setStatus('APPSTACK_RUNTIME_OK');
+      } catch (error) {
+        const message =
+          error && error.message ? error.message : String(error);
+        try {
+          await reportResult('failure', { message });
+        } catch (reportError) {
+          console.error(
+            FAILURE_PREFIX +
+              `could not report "${message}": ${String(reportError)}`
+          );
+        }
+        console.error(FAILURE_PREFIX + message);
+        setStatus('APPSTACK_RUNTIME_FAIL');
       }
     })();
   }, []);
@@ -150,18 +438,25 @@ export default function App() {
     </View>
   );
 }
-JS_BODY
-  } > "${app_dir}/App.js"
+JS
+  APPSTACK_RUNTIME_RESULT_URL="${APPSTACK_RUNTIME_PROXY_URL}/runtime-result" \
+    node -e "
+      const fs = require('fs');
+      const path = process.argv[1];
+      const marker = '__APPSTACK_RUNTIME_RESULT_URL__';
+      const source = fs.readFileSync(path, 'utf8');
+      if (!source.includes(marker)) throw new Error('runtime result URL marker missing');
+      fs.writeFileSync(
+        path,
+        source.replace(marker, process.env.APPSTACK_RUNTIME_RESULT_URL)
+      );
+    " "${app_dir}/App.js"
 }
 
-# Install the release APK on an available device, launch it, and poll logcat for
-# the success/failure sentinel. Success REQUIRES the JS sentinel APPSTACK_SMOKE_OK
-# (emitted only after the full configure -> sendEvent -> getAppstackId round trip);
-# the native "configure ... successfully" log is supplemental output only, since it
-# fires on configure alone and would otherwise let the check pass early.
 run_android_smoke() {
   local apk="$1" pkg="$2"
   local adb; adb="$(adb_bin)"
+  ANDROID_ADB="$adb"
 
   log "Waiting for an Android device/emulator..."
   "$adb" get-state >/dev/null 2>&1 || "$adb" wait-for-device
@@ -174,53 +469,42 @@ run_android_smoke() {
   done
   [[ "$booted" == "1" ]] || fail "No booted Android device/emulator available for --smoke"
 
-  log "Installing release APK: $(basename "$apk")"
+  log "Forwarding recorder ports into the Android device..."
+  "$adb" reverse "tcp:$RUNTIME_HTTP_PORT" "tcp:$RUNTIME_HTTP_PORT"
+  ANDROID_REVERSED_HTTP="$RUNTIME_HTTP_PORT"
+  "$adb" reverse "tcp:$RUNTIME_TLS_PORT" "tcp:$RUNTIME_TLS_PORT"
+  ANDROID_REVERSED_TLS="$RUNTIME_TLS_PORT"
+
+  log "Installing runtime APK: $(basename "$apk")"
   "$adb" install -r -d "$apk" >/dev/null || fail "adb install failed"
+  ANDROID_INSTALLED_PACKAGE="$pkg"
 
   "$adb" logcat -c || true
+  "$adb" logcat -v threadtime > "$RUNTIME_LOG" 2>&1 &
+  RUNTIME_LOG_PID=$!
   log "Launching $pkg ..."
   "$adb" shell monkey -p "$pkg" -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1 \
     || fail "Failed to launch $pkg"
 
-  local ok_js="APPSTACK_SMOKE_OK"
-  local fail_js="APPSTACK_SMOKE_FAIL"
-
-  log "Waiting for SDK round-trip sentinel in logcat (up to 90s)..."
-  local dump=""
-  for _ in $(seq 1 45); do
-    dump="$("$adb" logcat -d 2>/dev/null || true)"
-
-    # Immediate failure signals first, so a configure-then-fail run cannot slip
-    # through on the native configure log.
-    if grep -qF "$fail_js" <<<"$dump"; then
-      grep -F "$fail_js" <<<"$dump" | head -3 >&2
-      fail "SDK smoke FAILED at runtime (JS reported an error)"
+  log "Waiting for the terminal runtime result (up to 120s)..."
+  for _ in $(seq 1 60); do
+    if grep -qE '/runtime-result.*"kind": "failure"' "$REQUESTS_FILE" 2>/dev/null \
+        || grep -qF "APPSTACK_RUNTIME_FAIL:" "$RUNTIME_LOG"; then
+      fail "Runtime probe reported an error"
     fi
-    if grep -qE "FATAL EXCEPTION|AndroidRuntime.*com\.appstack\.e2e" <<<"$dump"; then
-      grep -E "FATAL EXCEPTION|AndroidRuntime" <<<"$dump" | head -8 >&2
-      fail "App crashed at runtime during smoke"
+    if grep -qE "FATAL EXCEPTION|AndroidRuntime.*com\.appstack\.e2e" "$RUNTIME_LOG"; then
+      fail "App crashed during the runtime check"
     fi
-
-    # Success requires the JS sentinel = full configure -> sendEvent ->
-    # getAppstackId round trip. The native log is printed only as context.
-    if grep -qF "$ok_js" <<<"$dump"; then
-      log "Smoke sentinel found (JS round-trip complete):"
-      grep -F "$ok_js" <<<"$dump" | head -1 | sed 's/^/    /'
+    if grep -qE '/runtime-result.*"kind": "success"' "$REQUESTS_FILE" 2>/dev/null; then
+      stop_runtime_log_capture
+      log "Terminal runtime result found"
       return 0
     fi
     sleep 2
   done
-  echo "---- last 40 logcat lines ----" >&2
-  "$adb" logcat -d 2>/dev/null | tail -40 >&2 || true
-  fail "Timed out waiting for SDK smoke sentinel (no round-trip confirmation)"
+  fail "Timed out waiting for the terminal runtime result"
 }
 
-# Install the .app on a booted simulator, launch it, and poll the unified log for
-# the sentinel. Success REQUIRES the JS sentinel APPSTACK_SMOKE_OK, emitted only
-# after the full configure -> sendEvent -> getAppstackId round trip. The bridge
-# itself no longer logs (device logging is delegated to the native SDK's
-# sanitized, level-gated logger), so the JS sentinel is the sole signal — and the
-# getAppstackId UUID it carries is native-backed proof the SDK initialized.
 run_ios_smoke() {
   local app_path="$1" bundle_id="$2"
   [[ -d "$app_path" ]] || fail ".app not found at $app_path"
@@ -235,55 +519,39 @@ run_ios_smoke() {
     xcrun simctl boot "$udid" || true
   fi
   xcrun simctl bootstatus "$udid" >/dev/null 2>&1 || true
+  IOS_RUNTIME_UDID="$udid"
 
   log "Installing app on simulator: $(basename "$app_path")"
   xcrun simctl install "$udid" "$app_path" || fail "simctl install failed"
+  IOS_INSTALLED_BUNDLE="$bundle_id"
 
-  # Capture the unified log (JS console output routed to os_log) in the
-  # background, filtered to our sentinel to keep it cheap.
-  local capture; capture="$(mktemp "${TMPDIR:-/tmp}/appstack-ios-smoke.XXXXXX")"
+  # Capture only Appstack/probe messages from the unified log. The terminal
+  # result itself travels through the recorder because Release JS console output
+  # is not consistently exposed by simctl across Xcode versions.
   xcrun simctl spawn "$udid" log stream --level debug --style syslog \
-    --predicate 'eventMessage CONTAINS "APPSTACK_SMOKE"' \
-    > "$capture" 2>/dev/null &
-  local log_pid=$!
+    --predicate 'eventMessage CONTAINS[c] "Appstack" OR eventMessage CONTAINS "APPSTACK_RUNTIME"' \
+    > "$RUNTIME_LOG" 2>&1 &
+  RUNTIME_LOG_PID=$!
   sleep 1
 
   log "Launching ${bundle_id} ..."
   xcrun simctl launch "$udid" "$bundle_id" >/dev/null 2>&1 \
-    || { kill "$log_pid" 2>/dev/null || true; fail "simctl launch failed"; }
+    || fail "Failed to launch $bundle_id"
 
-  local ok_js="APPSTACK_SMOKE_OK"
-  local fail_js="APPSTACK_SMOKE_FAIL"
-
-  log "Waiting for SDK round-trip sentinel in the simulator log (up to 90s)..."
-  local found=false
-  for _ in $(seq 1 45); do
-    # Immediate failure signal first, so a configure-then-fail run cannot slip
-    # through on the native configure log.
-    if grep -qF "$fail_js" "$capture"; then
-      kill "$log_pid" 2>/dev/null || true
-      grep -F "$fail_js" "$capture" | head -3 >&2
-      fail "SDK smoke FAILED at runtime (JS reported an error)"
+  log "Waiting for the terminal runtime result (up to 120s)..."
+  for _ in $(seq 1 60); do
+    if grep -qE '/runtime-result.*"kind": "failure"' "$REQUESTS_FILE" 2>/dev/null \
+        || grep -qF "APPSTACK_RUNTIME_FAIL:" "$RUNTIME_LOG"; then
+      fail "Runtime probe reported an error"
     fi
-    # Success requires the JS sentinel = full configure -> sendEvent ->
-    # getAppstackId round trip.
-    if grep -qF "$ok_js" "$capture"; then
-      found=true; break
+    if grep -qE '/runtime-result.*"kind": "success"' "$REQUESTS_FILE" 2>/dev/null; then
+      stop_runtime_log_capture
+      log "Terminal runtime result found"
+      return 0
     fi
     sleep 2
   done
-  kill "$log_pid" 2>/dev/null || true
-
-  if [[ "$found" == true ]]; then
-    log "Smoke sentinel found (JS round-trip complete):"
-    grep -F "$ok_js" "$capture" | head -1 | sed 's/^/    /'
-    rm -f "$capture"
-    return 0
-  fi
-  echo "---- last 40 captured log lines ----" >&2
-  tail -40 "$capture" >&2 || true
-  rm -f "$capture"
-  fail "Timed out waiting for SDK smoke sentinel (no round-trip confirmation)"
+  fail "Timed out waiting for the terminal runtime result"
 }
 
 log "Expo SDK ${SDK_VERSION} / ${PLATFORM} / ${ARCHITECTURE} architecture integration test (workdir: ${WORK_DIR})"
@@ -294,6 +562,8 @@ if [[ ! -d node_modules ]]; then
   log "Installing SDK dependencies..."
   npm ci
 fi
+PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+EXPECTED_WRAPPER_VERSION="react-native-${PACKAGE_VERSION}"
 log "Packing SDK tarball..."
 rm -f "${WORK_DIR}"/react-native-appstack-sdk-*.tgz
 npm pack --pack-destination "$WORK_DIR" > /dev/null
@@ -319,14 +589,11 @@ if [[ "$STATIC_FRAMEWORKS" == true ]]; then
   npm install --no-audit --no-fund expo-build-properties
 fi
 if [[ "$SMOKE_MODE" == true ]]; then
-  # Interim safety guard until the hermetic loopback recorder is introduced:
-  # repository smoke hosts must explicitly carry the repo-only native proxy
-  # configuration so a fake-key run cannot fall back to production endpoints.
-  cp "$ROOT_DIR/homepage-app/plugins/withAppstackDevProxy.js" \
-    "$APP_DIR/withAppstackDevProxy.js"
+  start_runtime_backend
 fi
 STATIC_FRAMEWORKS="$STATIC_FRAMEWORKS" SMOKE_MODE="$SMOKE_MODE" \
-  NEW_ARCH_ENABLED="$NEW_ARCH_ENABLED" WRITE_NEW_ARCH_CONFIG="$WRITE_NEW_ARCH_CONFIG" node -e "
+  NEW_ARCH_ENABLED="$NEW_ARCH_ENABLED" WRITE_NEW_ARCH_CONFIG="$WRITE_NEW_ARCH_CONFIG" \
+  APPSTACK_RUNTIME_PROXY_URL="${APPSTACK_RUNTIME_PROXY_URL:-}" node -e "
   const fs = require('fs');
   const j = JSON.parse(fs.readFileSync('app.json', 'utf8'));
   if (process.env.WRITE_NEW_ARCH_CONFIG === 'true') {
@@ -337,19 +604,49 @@ STATIC_FRAMEWORKS="$STATIC_FRAMEWORKS" SMOKE_MODE="$SMOKE_MODE" \
     delete j.expo.newArchEnabled;
   }
   j.expo.android = { ...(j.expo.android || {}), package: 'com.appstack.e2e' };
-  j.expo.ios = { ...(j.expo.ios || {}), bundleIdentifier: 'com.appstack.e2e' };
+
+  const existingIos = j.expo.ios || {};
+  const infoPlist = { ...(existingIos.infoPlist || {}) };
+  delete infoPlist.APPSTACK_DEV_PROXY_URL;
+  const appTransportSecurity = {
+    ...(infoPlist.NSAppTransportSecurity || {})
+  };
+  delete appTransportSecurity.NSAllowsLocalNetworking;
+  if (Object.keys(appTransportSecurity).length > 0) {
+    infoPlist.NSAppTransportSecurity = appTransportSecurity;
+  } else {
+    delete infoPlist.NSAppTransportSecurity;
+  }
+
+  if (process.env.SMOKE_MODE === 'true') {
+    if (!process.env.APPSTACK_RUNTIME_PROXY_URL) {
+      throw new Error('APPSTACK_RUNTIME_PROXY_URL is required in smoke mode');
+    }
+    infoPlist.APPSTACK_DEV_PROXY_URL = process.env.APPSTACK_RUNTIME_PROXY_URL;
+    infoPlist.NSAppTransportSecurity = {
+      ...(infoPlist.NSAppTransportSecurity || {}),
+      NSAllowsLocalNetworking: true
+    };
+  }
+  j.expo.ios = {
+    ...existingIos,
+    bundleIdentifier: 'com.appstack.e2e',
+    ...(Object.keys(infoPlist).length > 0 ? { infoPlist } : {})
+  };
+  if (Object.keys(infoPlist).length === 0) {
+    delete j.expo.ios.infoPlist;
+  }
+
   // Normalize repo-owned plugins so reused app dirs do not leak settings from
   // a previous run.
   const plugins = (j.expo.plugins || []).filter(
-    (p) => !['expo-build-properties', './withAppstackDevProxy'].includes(
-      Array.isArray(p) ? p[0] : p
-    )
+    (p) => ![
+      'expo-build-properties',
+      './withAppstackDevProxy'
+    ].includes(Array.isArray(p) ? p[0] : p)
   );
   if (process.env.STATIC_FRAMEWORKS === 'true') {
     plugins.push(['expo-build-properties', { ios: { useFrameworks: 'static' } }]);
-  }
-  if (process.env.SMOKE_MODE === 'true') {
-    plugins.push('./withAppstackDevProxy');
   }
   j.expo.plugins = plugins;
   fs.writeFileSync('app.json', JSON.stringify(j, null, 2));
@@ -361,6 +658,10 @@ rm -rf "$PLATFORM"
 CI=1 npx expo prebuild --platform "$PLATFORM" --no-install
 
 if [[ "$PLATFORM" == "android" ]]; then
+  if [[ "$SMOKE_MODE" == true ]]; then
+    configure_android_runtime_host "$APP_DIR/android"
+  fi
+
   ACTUAL_NEW_ARCH="$(sed -n 's/^newArchEnabled=//p' android/gradle.properties | tail -1)"
   if (( SDK_MAJOR >= 55 )); then
     [[ -z "$ACTUAL_NEW_ARCH" || "$ACTUAL_NEW_ARCH" == "true" ]] \
@@ -395,15 +696,34 @@ if [[ "$PLATFORM" == "android" ]]; then
   fi
 
   if [[ "$SMOKE_MODE" == true ]]; then
-    # 6a. Build a runnable release APK (Expo default: debug-signed, non-minified,
-    # JS bundle embedded → launches without Metro) and drive it on a device.
-    write_smoke_entrypoint "$APP_DIR"
-    log "Building Android app (assembleRelease, runnable/self-contained)..."
-    ./gradlew --no-daemon :app:assembleRelease
-    APK="$(ls app/build/outputs/apk/release/*.apk 2>/dev/null | head -1)"
-    [[ -n "$APK" ]] || fail "Release APK not found after assembleRelease"
+    # The short-lived test CA and proxy metadata exist only under src/debug.
+    # The generated debug variant bundles JS so it launches without Metro.
+    write_runtime_entrypoint "$APP_DIR"
+    grep -qF "$APPSTACK_RUNTIME_PROXY_URL" app/src/debug/AndroidManifest.xml \
+      || fail "Runtime proxy metadata is missing from the debug manifest"
+    [[ -f app/src/debug/res/raw/appstack_runtime_validation_ca.pem ]] \
+      || fail "Runtime CA is missing from the debug source set"
+    [[ ! -e app/src/main/res/raw/appstack_runtime_validation_ca.pem ]] \
+      || fail "Runtime CA leaked into the main source set"
+    grep -qF 'debuggableVariants = []' app/build.gradle \
+      || fail "Debug APK is not configured to bundle its JS"
+
+    log "Building Android runtime app (assembleDebug, self-contained)..."
+    if ! ./gradlew --no-daemon :app:assembleDebug \
+        > "$RUNTIME_DIR/android-build.log" 2>&1; then
+      tail -120 "$RUNTIME_DIR/android-build.log" >&2
+      fail "Android runtime build failed"
+    fi
+    APK="$(ls app/build/outputs/apk/debug/*.apk 2>/dev/null | head -1)"
+    [[ -n "$APK" ]] || fail "Debug APK not found after assembleDebug"
+    APK_CONTENTS="$(unzip -Z1 "$APK")"
+    grep -qF 'assets/index.android.bundle' <<<"$APK_CONTENTS" \
+      || fail "Debug APK does not contain its JS bundle"
     run_android_smoke "$APK" "com.appstack.e2e"
-    log "✅ Android runtime smoke passed (SDK bridge round-trip confirmed)"
+    python3 "$ROOT_DIR/integration-tests/validate_runtime.py" \
+      --requests-file "$REQUESTS_FILE" \
+      --expected-wrapper-version "$EXPECTED_WRAPPER_VERSION"
+    log "✅ Android hermetic runtime check passed"
   else
     # 6a. Full Android compile (debug — same Java compile path that release uses)
     log "Building Android app (assembleDebug)..."
@@ -447,21 +767,30 @@ else
   if [[ "$SMOKE_MODE" == true ]]; then
     # Release embeds the JS bundle → the app launches without Metro. Simulator
     # builds need no code signing.
-    write_smoke_entrypoint "$APP_DIR"
+    write_runtime_entrypoint "$APP_DIR"
     log "Building iOS app (xcodebuild Release, runnable/self-contained; scheme ${SCHEME})..."
-    xcodebuild -workspace "$WORKSPACE" \
-      -scheme "$SCHEME" \
-      -configuration Release \
-      -sdk iphonesimulator \
-      -destination 'generic/platform=iOS Simulator' \
-      -derivedDataPath build \
-      CODE_SIGNING_ALLOWED=NO \
-      COMPILER_INDEX_STORE_ENABLE=NO \
-      build
+    if ! xcodebuild -workspace "$WORKSPACE" \
+        -scheme "$SCHEME" \
+        -configuration Release \
+        -sdk iphonesimulator \
+        -destination 'generic/platform=iOS Simulator' \
+        -derivedDataPath build \
+        CODE_SIGNING_ALLOWED=NO \
+        COMPILER_INDEX_STORE_ENABLE=NO \
+        build > "$RUNTIME_DIR/ios-build.log" 2>&1; then
+      tail -120 "$RUNTIME_DIR/ios-build.log" >&2
+      fail "iOS runtime build failed"
+    fi
     APP_PATH="$(ls -d build/Build/Products/Release-iphonesimulator/*.app 2>/dev/null | head -1)"
     [[ -n "$APP_PATH" ]] || fail "Built .app not found after Release build"
+    PLIST_PROXY="$(plutil -extract APPSTACK_DEV_PROXY_URL raw "$APP_PATH/Info.plist")"
+    [[ "$PLIST_PROXY" == "$APPSTACK_RUNTIME_PROXY_URL" ]] \
+      || fail "Built iOS app does not contain the loopback runtime proxy"
     run_ios_smoke "$APP_PATH" "com.appstack.e2e"
-    log "✅ iOS runtime smoke passed (SDK bridge round-trip confirmed)"
+    python3 "$ROOT_DIR/integration-tests/validate_runtime.py" \
+      --requests-file "$REQUESTS_FILE" \
+      --expected-wrapper-version "$EXPECTED_WRAPPER_VERSION"
+    log "✅ iOS hermetic runtime check passed"
   else
     log "Building iOS app (xcodebuild, scheme ${SCHEME})..."
     xcodebuild -workspace "$WORKSPACE" \

--- a/integration-tests/validate_runtime.py
+++ b/integration-tests/validate_runtime.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Validate the JS result and native HTTP traffic from a runtime check."""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def load_json_lines(path: Path):
+    if not path.is_file():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines()
+        if line.strip()
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--requests-file", required=True)
+    parser.add_argument("--expected-wrapper-version", required=True)
+    args = parser.parse_args()
+
+    requests = load_json_lines(Path(args.requests_file))
+    require(requests, "recording backend received no native SDK requests")
+    result_entries = [
+        item.get("body")
+        for item in requests
+        if item.get("path", "").split("?", 1)[0] == "/runtime-result"
+        and item.get("body")
+    ]
+    require(result_entries, "recording backend received no terminal validation result")
+    terminal = result_entries[-1]
+    require(
+        terminal.get("kind") == "success",
+        f"runtime probe reported an error: {terminal.get('payload')}",
+    )
+    result = terminal.get("payload") or {}
+
+    require(result.get("configured") is True, "wrapper configuration did not complete")
+    require(result.get("appstackIdPresent") is True, "native SDK returned no Appstack ID")
+    require(result.get("sdkDisabled") is False, "native SDK reports disabled")
+    require(result.get("callbackCount") == 3, "not all attribution calls completed")
+    require(result.get("successCount") == 3, "attribution calls did not all succeed")
+    require(
+        result.get("attributionValidated") is True,
+        "attribution payload was corrupted across the bridge",
+    )
+    require(result.get("eventsAccepted") == 2, "wrapper did not accept both events")
+    require(
+        result.get("validationError") == "Either eventName or eventType must be provided",
+        "wrapper did not return the expected meaningful validation error",
+    )
+    require(not result.get("errors"), f"runtime errors: {result.get('errors')}")
+
+    require(
+        any(item["path"].split("?", 1)[0].endswith("/config") for item in requests),
+        "native SDK did not fetch remote configuration",
+    )
+    require(
+        any("/attribution/match" in item["path"] for item in requests),
+        "native SDK did not perform attribution matching",
+    )
+
+    events = [
+        item["body"]
+        for item in requests
+        if item["path"].split("?", 1)[0].endswith("/events") and item.get("body")
+    ]
+    custom = next(
+        (
+            event
+            for event in events
+            if event.get("event_name") == "runtime_validation_custom"
+        ),
+        None,
+    )
+    login = next(
+        (event for event in events if event.get("event_name") == "LOGIN"), None
+    )
+    require(custom is not None, "custom event never reached the native wire boundary")
+    require(login is not None, "standard event never reached the native wire boundary")
+    require(
+        custom.get("wrapper_version") == args.expected_wrapper_version,
+        "wrong wrapper version on event",
+    )
+    require(
+        custom.get("customer_user_id") == "runtime-validation-user",
+        "customer user ID was not forwarded",
+    )
+
+    parameters = custom.get("custom_parameters") or {}
+    require(parameters.get("string") == "bridge-value", "string parameter changed")
+    require(parameters.get("number") == 42, "integer parameter changed")
+    require(parameters.get("decimal") == 9.75, "decimal parameter changed")
+    require(parameters.get("boolean") is True, "boolean parameter changed")
+    require(parameters.get("unicode") == "café 🚀", "UTF-8 parameter changed")
+    require(
+        parameters.get("array") == ["one", 2, False], "array parameter changed"
+    )
+    require(
+        parameters.get("nested") == {
+            "enabled": True,
+            "items": ["nested", 3, False],
+        },
+        "nested parameters changed",
+    )
+
+    login_parameters = login.get("custom_parameters") or {}
+    require(
+        login_parameters.get("state") == "ready",
+        "standard event string parameter changed",
+    )
+    require(
+        login_parameters.get("sequence") == 2,
+        "standard event numeric parameter changed",
+    )
+
+    print(
+        json.dumps(
+            {
+                "platform": result.get("platform"),
+                "attributionCalls": result.get("callbackCount"),
+                "eventsRecorded": len(events),
+                "wrapperVersion": custom.get("wrapper_version"),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (AssertionError, json.JSONDecodeError, OSError) as error:
+        raise SystemExit(f"runtime validation failed: {error}") from None

--- a/ios/AppstackBridge.swift
+++ b/ios/AppstackBridge.swift
@@ -31,9 +31,9 @@ public class AppstackBridge: NSObject {
         // Testing-only proxy override, read from the app's Info.plist. This is NOT
         // exposed through the public configure() API: a proxy URL is applied only if
         // the host app deliberately ships an APPSTACK_DEV_PROXY_URL key (this repo's
-        // homepage-app does; published-package consumers do not). Routed through the
-        // SDK's @_spi setProxyUrl(_:) hook and applied before configure so the SDK's
-        // initial requests target it.
+        // demo/test hosts do; published-package consumers do not). Routed through
+        // the SDK's @_spi setProxyUrl(_:) hook and applied before configure so the
+        // SDK's initial requests target it.
         if let devProxyUrl = (Bundle.main.object(forInfoDictionaryKey: "APPSTACK_DEV_PROXY_URL") as? String)
             .flatMap({ $0.isEmpty ? nil : $0 }) {
             AppstackAttributionSdk.shared.setProxyUrl(devProxyUrl)


### PR DESCRIPTION
## Summary

This PR makes the React Native SDK integration suite deterministic, broadens Expo compatibility coverage, and separates fast change validation from the complete release matrix.

- removes the committed demo API key and keeps development proxy routing restricted to repository-owned demo/test hosts
- adds explicit Expo SDK and React Native architecture coverage, including the last supported legacy-architecture boundary
- replaces backend-dependent runtime smoke checks with a loopback-only recorder that validates the public JavaScript API, React Native bridge, real native SDK, and emitted requests
- splits focused PR/RC checks from the full stable/manual compatibility matrix
- hardens workflow permissions, action pinning, tag validation, and release ordering

## Why

The previous integration script proved that a fresh Expo application could autolink and compile, but its runtime smoke test only waited for a JavaScript sentinel after `configure`, `sendEvent`, and `getAppstackId`. It did not deterministically verify the native HTTP contract, and SDK traffic could depend on an external Appstack environment.

That left several gaps:

- backend availability or configuration could make tests flaky
- a fake test key could still result in unintended external traffic
- request routing, attribution responses, event payloads, wrapper version, and callback behavior were not asserted end to end
- legacy architecture, static frameworks, and the Xcode 26.2 compatibility boundary were not represented in a deliberate release gate
- running the complete matrix for every PR or RC would make iteration unnecessarily slow

## What changed

### Hermetic runtime validation

The Android and iOS runtime jobs now create a fresh Expo 57 app and exercise:

1. the public React Native API
2. the JavaScript-to-native bridge
3. the actual Appstack native SDK
4. native requests sent to a local recording backend

The local backend binds only to `127.0.0.1`, returns deterministic configuration and attribution responses, and records sanitized request summaries. The validator checks configuration, SDK state and UUID, attribution callbacks, customer user ID, custom and login events, rich value types (including nested data and Unicode), wrapper version, and expected error behavior.

Android uses `adb reverse`, a one-run certificate, and debug-only network configuration. iOS injects the loopback proxy through the generated app's `Info.plist` and runs a Release simulator build. Generated trust material, reverse mappings, temporary apps, servers, and log capture are cleaned up after each run.

### Compatibility matrix

Full compatibility checks cover:

- Android and iOS on Expo SDK 54, 55, and 56 with the new architecture
- Android and iOS on Expo SDK 54 with the legacy architecture
- the Expo 54 legacy iOS case on Xcode 26.2
- Expo 56 iOS with static frameworks

For Expo 55+, the harness verifies the mandatory new architecture without writing the removed `newArchEnabled` app-config property.

### CI and release behavior

| Trigger | Checks |
| --- | --- |
| Pull request to `main` | Package checks + Expo 57 Android runtime + Expo 57 iOS runtime |
| RC tag | Same focused checks before npm publication |
| Stable tag | Focused checks + full compatibility matrix before npm publication and GitHub release |
| Manual workflow | Full matrix by default, with an option to run only focused checks |

A single aggregate `Integration tests` job reports the gate result so branch protection does not need to change when matrix entries are added.

### Security and workflow hardening

- replaces the committed sample API key with local environment configuration and documentation
- keeps the proxy hook out of the public `configure()` API
- uses a fake runtime key and loopback-only traffic
- redacts sensitive headers and query values from recorder output
- rejects unknown paths and oversized request bodies
- pins third-party GitHub Actions to commit SHAs
- disables persisted checkout credentials and applies read-only workflow permissions where possible
- validates release tags before using them in shell commands
- requires integration checks to pass before package publication

## Validation

Completed locally:

- `./build.sh --ci --clean`
- `./integration-tests/run.sh 57 --platform android --architecture new --smoke`
- `./integration-tests/run.sh 57 --platform ios --architecture new --smoke`
- shell syntax, Python syntax, XML parsing, formatting, and diff hygiene checks

The focused GitHub Actions checks will run when this PR is opened.
