### PR TITLE
Fix Android snapshot repository resolution

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,13 +75,27 @@ android {
 
 }
 
-repositories {
-    // Put mavenLocal() first to prioritize local dependencies
-    google()
-    mavenCentral()
-    maven {
-        url "https://central.sonatype.com/repository/maven-snapshots/"
-        mavenContent { snapshotsOnly() }
+// Transitive dependencies are resolved with the consuming app's repositories,
+// not this library project's repositories. Configure every root project so Expo
+// and bare React Native apps route Appstack snapshots directly to Sonatype.
+rootProject.allprojects {
+    repositories {
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name = 'appstackSnapshots'
+                    url = uri('https://central.sonatype.com/repository/maven-snapshots/')
+                    mavenContent { snapshotsOnly() }
+                }
+            }
+            filter {
+                includeVersionByRegex(
+                    'tech\\.appstack\\.android-sdk',
+                    'appstack-android-sdk',
+                    '.*-SNAPSHOT'
+                )
+            }
+        }
     }
 }
 
@@ -162,5 +176,3 @@ tasks.configureEach { task ->
         task.finalizedBy 'realign16KBLibraries'
     }
 }
-
-


### PR DESCRIPTION
## Summary

- configure the Appstack snapshot repository on consuming root projects
- route only `tech.appstack.android-sdk:appstack-android-sdk:*-SNAPSHOT` coordinates exclusively to Sonatype
- leave stable Android SDK versions on Maven Central

## Root cause

React Native library project repositories are not used when the consuming app resolves transitive dependencies. Expo also places JitPack ahead of the library repository, and JitPack returned HTTP 401 for `1.5.1-SNAPSHOT`, stopping Gradle before it could reach Sonatype.

## Impact

Expo and bare React Native apps can resolve Appstack RC/snapshot Android SDK builds from the new Sonatype snapshot repository without requiring JitPack credentials.

## Validation

- `git diff --check`
- `./integration-tests/run.sh 57 --platform android` against `appstack-android-sdk:1.5.1-SNAPSHOT`
- generated Expo SDK 57 app completed `:app:assembleDebug` successfully
