### PR TITLE
Drive the Android snapshot repository off a single version declaration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,26 +75,53 @@ android {
 
 }
 
-// Transitive dependencies are resolved with the consuming app's repositories,
-// not this library project's repositories. Configure every root project so Expo
-// and bare React Native apps route Appstack snapshots directly to Sonatype.
-rootProject.allprojects {
-    repositories {
-        exclusiveContent {
-            forRepository {
-                maven {
-                    name = 'appstackSnapshots'
-                    url = uri('https://central.sonatype.com/repository/maven-snapshots/')
-                    mavenContent { snapshotsOnly() }
+// The one place the native Android SDK version is declared. To test a release
+// candidate, point this at the RC's snapshot coordinate and everything below
+// adjusts itself. Stable releases must always ship a plain release version:
+// snapshots are mutable and expire.
+def appstackAndroidSdkVersion = '1.7.0-SNAPSHOT'
+def appstackAndroidSdkIsSnapshot = appstackAndroidSdkVersion.endsWith('-SNAPSHOT')
+
+// Release candidates of the native SDK are published to the Central Portal
+// snapshot repository, which mavenCentral() does not serve. Register it only
+// while this library is pinned to a snapshot, so a released version adds
+// nothing to a host app's build.
+//
+// It has to be registered on every *root* project, not just here: transitive
+// dependencies are resolved with the consuming app's repositories, not this
+// library project's. Configuring every root project is what makes Expo and
+// bare React Native apps route Appstack snapshots to Sonatype.
+if (appstackAndroidSdkIsSnapshot) {
+    rootProject.allprojects {
+        repositories {
+            exclusiveContent {
+                forRepository {
+                    maven {
+                        name = 'appstackSnapshots'
+                        url = uri('https://central.sonatype.com/repository/maven-snapshots/')
+                        mavenContent { snapshotsOnly() }
+                    }
+                }
+                // Only Appstack snapshots come from here. Every other
+                // dependency — and every stable Appstack release — keeps
+                // resolving through the app's own repositories.
+                filter {
+                    includeVersionByRegex(
+                        'tech\\.appstack\\.android-sdk',
+                        'appstack-android-sdk',
+                        '.*-SNAPSHOT'
+                    )
                 }
             }
-            filter {
-                includeVersionByRegex(
-                    'tech\\.appstack\\.android-sdk',
-                    'appstack-android-sdk',
-                    '.*-SNAPSHOT'
-                )
-            }
+        }
+
+        // A snapshot coordinate is mutable: re-pushing an RC replaces the
+        // artifact in place. Gradle caches changing modules for 24 hours by
+        // default, so a rebuild with a warm dependency cache can silently keep
+        // testing the previous artifact — including CI, which restores a
+        // persisted Gradle cache. Always re-check while on an RC.
+        configurations.configureEach {
+            resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
         }
     }
 }
@@ -102,7 +129,7 @@ rootProject.allprojects {
 dependencies {
     compileOnly 'com.facebook.react:react-native:+'
 
-    implementation 'tech.appstack.android-sdk:appstack-android-sdk:1.5.0'
+    implementation "tech.appstack.android-sdk:appstack-android-sdk:$appstackAndroidSdkVersion"
 
     implementation 'androidx.annotation:annotation:1.7.1'
 


### PR DESCRIPTION
Follow-up to #34, which registered the Central Portal snapshot repository so native SDK release candidates resolve at all. Two things it left behind:

- **The repository was registered unconditionally.** With a stable pin (`1.5.0` on `main` today), a published package still added the Sonatype snapshot repository to every consumer app's build. It is now registered only while the pin is a `-SNAPSHOT`.
- **The version was declared inline in `dependencies`.** Testing an RC meant editing one place while remembering the repository block existed elsewhere. There is now a single `appstackAndroidSdkVersion` declaration that both the dependency and the repository registration follow.

Also adds `resolutionStrategy.cacheChangingModulesFor 0, 'seconds'`. A snapshot coordinate is mutable — re-pushing an RC replaces the artifact in place — and Gradle caches changing modules for 24 hours by default, so a warm cache (including CI's persisted one) can silently keep testing the previous artifact.

Pins `1.7.0-SNAPSHOT`, the release candidate carrying the native `setCustomerUserId` setter.

### Verification

The wrapper's Kotlin module compiles against the real published artifact (`1.7.0-20260803.205553-1`), which exports `public static final void setCustomerUserId(java.lang.String)`.

### Note

`1.7.0-SNAPSHOT` is mutable and expires. This must go back to a plain release version before a stable publish — the comment in `build.gradle` says so, but it is worth a release-checklist item too.
