### PR TITLE
Publish to npm via trusted publishing (OIDC) instead of a token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,12 @@ jobs:
       with:
         node-version: '24'
         registry-url: 'https://registry.npmjs.org'
-        cache: 'npm'
+        # No dependency cache on the release job. It saves only a few seconds on a
+        # job that runs a handful of times a month, and this is the one job holding
+        # npm publish rights. `package-manager-cache: false` also disables the
+        # auto-detect fallback, which an explicit `cache` input would otherwise
+        # take precedence over (actions/setup-node src/main.ts).
+        package-manager-cache: false
     - name: Extract and validate version from tag
       id: get_version
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,12 @@ jobs:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
+    # Node 24 bundles npm 11.x, which trusted publishing (OIDC) requires. Node 22
+    # still bundles npm 10.9.x and cannot perform the OIDC exchange at all, so do
+    # not lower this pin to match the other workflows.
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '18'
+        node-version: '24'
         registry-url: 'https://registry.npmjs.org'
         cache: 'npm'
     - name: Extract and validate version from tag
@@ -80,12 +83,31 @@ jobs:
     - name: Create npm package
       run: npm pack
 
+    # Authenticates via npm trusted publishing (OIDC), backed by the workflow's
+    # `id-token: write` permission and the trusted publisher configured on the
+    # package. There is no NPM_TOKEN to rotate, expire, or have revoked. Provenance
+    # attestations are generated automatically, so no --provenance flag is needed.
     - name: Publish to npm
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         VERSION: ${{ steps.get_version.outputs.version }}
       run: |
         set -euo pipefail
+        # Trusted publishing needs npm >= 11.5.1. Fail loudly rather than silently
+        # falling back to token auth, which no longer has a token to fall back to.
+        REQUIRED_NPM="11.5.1"
+        ACTUAL_NPM="$(npm --version)"
+        if [[ "$(printf '%s\n%s\n' "$REQUIRED_NPM" "$ACTUAL_NPM" | sort -V | head -n1)" != "$REQUIRED_NPM" ]]; then
+          echo "::error::npm $ACTUAL_NPM is too old for trusted publishing (need >= $REQUIRED_NPM)"
+          exit 1
+        fi
+        # actions/setup-node writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`
+        # into its npmrc. With no token in the environment that expands to an empty
+        # string, which npm reads as "auth is already configured" — it then skips the
+        # OIDC exchange and publishes with empty credentials, failing with E404.
+        NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+        if [[ -f "$NPMRC" ]]; then
+          sed -i '/_authToken/d' "$NPMRC"
+        fi
         if [[ "$VERSION" == *-* ]]; then
           npm publish --access public --tag rc
           echo "✅ Published $VERSION under the 'rc' dist-tag"


### PR DESCRIPTION
## Why

The `3.0.0-rc1` tag failed to publish ([run 32408897672](https://github.com/appstack-tech/react-native-appstack-sdk/actions/runs/32408897672)). Every check passed; only the `publish` job's **Publish to npm** step failed:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/react-native-appstack-sdk
```

A 404 on `PUT` to a package that exists is npm's *unauthorized* signature — it returns 404 rather than 403 so package existence isn't leaked. The `NPM_TOKEN` secret was written **2026-05-20**, the day after npm [invalidated granular write tokens that bypass 2FA](https://github.com/orgs/community/discussions/196340), and write tokens carry a [90-day maximum lifetime](https://github.blog/changelog/2025-11-05-npm-security-update-classic-token-creation-disabled-and-granular-token-changes/) with no opt-out. That puts expiry at **2026-08-18** — between the last successful publish (`3.0.0-rc0`, Aug 17) and this failure (Aug 20).

## What was already in place

A trusted publisher is configured on the package for this repo + `build.yml` with `npm publish` permission, and the workflow already grants `id-token: write`. None of it was reachable: the job pinned **Node 18**, whose bundled npm 9.x has no OIDC support, so every publish silently went through classic token auth instead.

## The change

- **Node 18 → 24.** Not `'22'` like the other workflows: Node 22 bundles npm 10.9.x, below the **11.5.1** trusted publishing requires. Node 24 bundles npm 11.17.0. `build.sh --ci --clean` already runs on Node 22 in `integration-tests.yml`, so the build path isn't newly exercised.
- **Removed `NODE_AUTH_TOKEN`.** Authentication is now OIDC.
- **npm version guard**, so a future pin below 11.5.1 fails loudly rather than silently reverting to token auth with no token behind it.
- **Strips the `_authToken` line** `actions/setup-node` writes into its npmrc. With no token in the environment the `${NODE_AUTH_TOKEN}` placeholder expands to empty, which npm reads as "auth is already configured" — it skips the OIDC exchange and publishes with empty credentials, failing with the same `E404` this PR fixes ([npm/documentation#1960](https://github.com/npm/documentation/issues/1960)).

Provenance attestations now come for free — npm generates them automatically for trusted publishing, so no `--provenance` flag is needed.

## Why not just rotate the token

Write tokens expire every 90 days minimum, so this recurs around mid-November. And [bypass-2FA tokens lose direct publish around January 2027](https://github.blog/changelog/2026-07-31-restricting-npm-bypass-2fa-granular-access-tokens/), reducing to staged publish with human 2FA approval — at which point token-based CI publishing stops working entirely.

## Verification

`build.yml` parses as valid YAML, workflow-level `permissions` are inherited by `publish` (no job-level override), the publish script passes `bash -n`, and the version gate was tested against 10.9.8 / 11.4.9 / 11.5.1 / 11.17.0 / 12.0.0. **The OIDC exchange itself is unverified** — it can only be exercised by a real tag push.

## Follow-ups after this is proven green

- Set the package's publishing access to "Require two-factor authentication and disallow tokens".
- Delete the now-unused `NPM_TOKEN` secret.